### PR TITLE
remove borders from single–line–tall list items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ target/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 *.db
+*~

--- a/src/view/widgets/manga.rs
+++ b/src/view/widgets/manga.rs
@@ -87,10 +87,12 @@ impl Widget for ChapterItem {
             None => match self.state {
                 ChapterItemState::Normal => {
                     Paragraph::new(self.scanlator)
+                        .style(self.style)
                         .wrap(Wrap { trim: true })
                         .render(scanlator_area, buf);
 
                     Paragraph::new(self.readable_at)
+                        .style(self.style)
                         .wrap(Wrap { trim: true })
                         .render(readable_at_area, buf);
                 }
@@ -134,7 +136,7 @@ impl Widget for ChapterItem {
 impl PreRender for ChapterItem {
     fn pre_render(&mut self, context: &tui_widget_list::PreRenderContext) -> u16 {
         if context.is_selected {
-            self.style = Style::new().fg(Color::Yellow);
+            self.style = Style::new().fg(Color::Yellow).bg(Color::Blue);
         }
 
         if self.download_loading_state.is_some() {

--- a/src/view/widgets/manga.rs
+++ b/src/view/widgets/manga.rs
@@ -37,28 +37,35 @@ impl Widget for ChapterItem {
         Self: Sized,
     {
         let layout = Layout::horizontal([
-            Constraint::Percentage(50),
-            Constraint::Percentage(30),
-            Constraint::Percentage(20),
+            Constraint::Length(3),
+            Constraint::Length(3),
+            Constraint::Length(3),
+            Constraint::Fill(50),
+            Constraint::Fill(30),
+            Constraint::Fill(20),
         ]);
 
-        Block::bordered().border_style(self.style).render(area, buf);
-
-        let [title_area, scanlator_area, readable_at_area] = layout.areas(area.inner(Margin {
-            horizontal: 1,
-            vertical: 1,
-        }));
+        let [is_read_area, is_downloaded_area, lang_area, title_area, scanlator_area, readable_at_area] =
+            layout.areas(area.inner(Margin {
+                horizontal: 0,
+                vertical: 0,
+            }));
 
         let is_read_icon = if self.is_read { "👀" } else { " " };
 
         let is_downloaded_icon = if self.is_downloaded { "📥" } else { " " };
 
+        Line::from(is_read_icon)
+            .style(self.style)
+            .render(is_read_area, buf);
+        Line::from(is_downloaded_icon)
+            .style(self.style)
+            .render(is_downloaded_area, buf);
+        Line::from(self.translated_language.as_emoji())
+            .style(self.style)
+            .render(lang_area, buf);
+
         Paragraph::new(Line::from(vec![
-            is_read_icon.into(),
-            " ".into(),
-            is_downloaded_icon.into(),
-            " ".into(),
-            self.translated_language.as_emoji().into(),
             format!(" Ch. {} ", self.chapter_number).into(),
             self.title.into(),
         ]))
@@ -136,7 +143,7 @@ impl PreRender for ChapterItem {
         if self.download_loading_state.is_some() {
             5
         } else {
-            3
+            1
         }
     }
 }

--- a/src/view/widgets/manga.rs
+++ b/src/view/widgets/manga.rs
@@ -46,10 +46,7 @@ impl Widget for ChapterItem {
         ]);
 
         let [is_read_area, is_downloaded_area, lang_area, title_area, scanlator_area, readable_at_area] =
-            layout.areas(area.inner(Margin {
-                horizontal: 0,
-                vertical: 0,
-            }));
+            layout.areas(area);
 
         let is_read_icon = if self.is_read { "👀" } else { " " };
 

--- a/src/view/widgets/search.rs
+++ b/src/view/widgets/search.rs
@@ -131,7 +131,6 @@ impl Widget for MangaItem {
     {
         Paragraph::new(self.manga.title)
             .wrap(Wrap { trim: true })
-            .block(Block::bordered().style(self.style))
             .style(self.style)
             .render(area, buf);
     }
@@ -142,7 +141,7 @@ impl PreRender for MangaItem {
         if context.is_selected {
             self.style = Style::default().fg(Color::Yellow);
         }
-        4
+        1
     }
 }
 


### PR DESCRIPTION
Since list items are generally a single line tall, putting borders around them seems a bit excessive. Also, line up the read/downloaded/language emoji into columns in the chapter list for extra neatness.
