### PR TITLE
bump ratatui to 0.28.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,6 +471,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,16 +566,16 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crossterm"
-version = "0.27.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.5.0",
  "crossterm_winapi",
  "futures-core",
- "libc",
- "mio",
+ "mio 1.0.2",
  "parking_lot",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1347,6 +1361,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "instability"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b23a0c8dfe501baac4adf6ebbfa6eddf8f0c07f56b058cc1288017e32397846c"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1564,7 +1588,7 @@ dependencies = [
  "image",
  "once_cell",
  "open",
- "ratatui",
+ "ratatui 0.28.0",
  "ratatui-image",
  "reqwest",
  "rusqlite",
@@ -1625,9 +1649,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "log",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2096,13 +2132,33 @@ checksum = "d16546c5b5962abf8ce6e2881e722b4e0ae3b6f1a08a26ae3573c55853ca68d3"
 dependencies = [
  "bitflags 2.5.0",
  "cassowary",
- "compact_str",
+ "compact_str 0.7.1",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "stability",
+ "strum",
+ "strum_macros",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba6a365afbe5615999275bea2446b970b10a41102500e27ce7678d50d978303"
+dependencies = [
+ "bitflags 2.5.0",
+ "cassowary",
+ "compact_str 0.8.0",
  "crossterm",
+ "instability",
  "itertools 0.13.0",
  "lru",
  "palette",
  "paste",
- "stability",
  "strum",
  "strum_macros",
  "time",
@@ -2114,14 +2170,15 @@ dependencies = [
 [[package]]
 name = "ratatui-image"
 version = "1.0.5"
-source = "git+https://github.com/josueBarretogit/ratatui-image#afbdd4e79251ef0709e4a2d9281b3ac6eb73291a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de94276254cb20fb7431726875bd2ac6391a6ffc26f4b8e3d23f79d1286b491e"
 dependencies = [
  "base64",
  "dyn-clone",
  "icy_sixel",
  "image",
  "rand",
- "ratatui",
+ "ratatui 0.27.0",
  "rustix",
 ]
 
@@ -2454,7 +2511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio",
+ "mio 1.0.2",
  "signal-hook",
 ]
 
@@ -2690,12 +2747,12 @@ dependencies = [
 
 [[package]]
 name = "throbber-widgets-tui"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685391f5e78b08989c1014f5a0edddf6751e0726b6a8dd1bdcc98d05921b19b6"
+checksum = "fad9e055cadd9da8b4a67662b962e3e67e96af491ae9cec7e88aaff92e7c3666"
 dependencies = [
  "rand",
- "ratatui",
+ "ratatui 0.28.0",
 ]
 
 [[package]]
@@ -2749,7 +2806,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
+ "mio 0.8.11",
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
@@ -2903,21 +2960,21 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tui-input"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e785f863a3af4c800a2a669d0b64c879b538738e352607e2624d03f868dc01"
+checksum = "68699e8bb4ca025ab41fcc602d3d53a5714a56b0cf2d6e93c98aaf4231e3d937"
 dependencies = [
- "crossterm",
+ "ratatui 0.28.0",
  "unicode-width",
 ]
 
 [[package]]
 name = "tui-widget-list"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf538b06ca860a3ac3ef3ed43f56bbfa4702b5d474822adf0d27a1cec3bd8c6e"
+checksum = "884b5d63dd439c721ec28ae1a19cbc9cb9dc151bd2d00940e94ba4dc728a236e"
 dependencies = [
- "ratatui",
+ "ratatui 0.28.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,19 +459,6 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "compact_str"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
-name = "compact_str"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644"
@@ -1588,7 +1575,7 @@ dependencies = [
  "image",
  "once_cell",
  "open",
- "ratatui 0.28.0",
+ "ratatui",
  "ratatui-image",
  "reqwest",
  "rusqlite",
@@ -2126,33 +2113,13 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16546c5b5962abf8ce6e2881e722b4e0ae3b6f1a08a26ae3573c55853ca68d3"
-dependencies = [
- "bitflags 2.5.0",
- "cassowary",
- "compact_str 0.7.1",
- "itertools 0.13.0",
- "lru",
- "paste",
- "stability",
- "strum",
- "strum_macros",
- "unicode-segmentation",
- "unicode-truncate",
- "unicode-width",
-]
-
-[[package]]
-name = "ratatui"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ba6a365afbe5615999275bea2446b970b10a41102500e27ce7678d50d978303"
 dependencies = [
  "bitflags 2.5.0",
  "cassowary",
- "compact_str 0.8.0",
+ "compact_str",
  "crossterm",
  "instability",
  "itertools 0.13.0",
@@ -2178,7 +2145,7 @@ dependencies = [
  "icy_sixel",
  "image",
  "rand",
- "ratatui 0.27.0",
+ "ratatui",
  "rustix",
 ]
 
@@ -2580,16 +2547,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stability"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff9eaf853dec4c8802325d8b6d3dffa86cc707fd7a1a4cdbf416e13b061787a"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2752,7 +2709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad9e055cadd9da8b4a67662b962e3e67e96af491ae9cec7e88aaff92e7c3666"
 dependencies = [
  "rand",
- "ratatui 0.28.0",
+ "ratatui",
 ]
 
 [[package]]
@@ -2964,7 +2921,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68699e8bb4ca025ab41fcc602d3d53a5714a56b0cf2d6e93c98aaf4231e3d937"
 dependencies = [
- "ratatui 0.28.0",
+ "ratatui",
  "unicode-width",
 ]
 
@@ -2974,7 +2931,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884b5d63dd439c721ec28ae1a19cbc9cb9dc151bd2d00940e94ba4dc728a236e"
 dependencies = [
- "ratatui 0.28.0",
+ "ratatui",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,23 +20,23 @@ include = [
 
 [dependencies]
 anyhow = "1.0.86"
-crossterm = { version = "0.27.0", features = ["event-stream"] }
+ratatui = { version = "0.28.0", features = ["all-widgets", "palette", "unstable-widget-ref"] }
+ratatui-image = {  version = "1.0.5", features = ["rustix"]}
+throbber-widgets-tui = "0.7.0"
+tui-input = "0.10.0"
+tui-widget-list = "0.12.0"
+crossterm = { version = "0.28.1", features = ["event-stream"] }
 directories = "5.0.1"
 image = "0.25.1"
-ratatui = { version = "0.27.0", features = ["all-widgets", "palette", "unstable-widget-ref"] }
-ratatui-image = { git = "https://github.com/josueBarretogit/ratatui-image", version = "1.0.2", features = ["rustix"]}
 reqwest = { version = "0.12.4", features = ["json"] }
 serde = { version = "1.0.203", features = ["derive"] }
 tokio = { version = "1.38.0", features = ["full"] }
-throbber-widgets-tui = "0.6.0"
 strum = "0.26.2"
 strum_macros = "0.26"
 color-eyre = "0.6.2"
-tui-input = "0.8.0"
 futures = "0.3.28"
 bytes = { version = "1", features = ["serde"] }
 serde_json = "1.0.117"
-tui-widget-list = "0.10.0"
 once_cell = "1.19.0"
 chrono = "0.4.38"
 open = "5"

--- a/src/backend/tui.rs
+++ b/src/backend/tui.rs
@@ -6,7 +6,7 @@ use crossterm::execute;
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen};
 use futures::{FutureExt, StreamExt};
 use ratatui::backend::Backend;
-use ratatui::prelude::*;
+use ratatui::Terminal;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::task::JoinHandle;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,11 @@
 #![forbid(unsafe_code)]
 #![allow(dead_code)]
 use std::time::Duration;
-
 use clap::Parser;
 use once_cell::sync::Lazy;
 use ratatui::backend::CrosstermBackend;
 use ratatui_image::picker::{Picker, ProtocolType};
 use reqwest::{Client, StatusCode};
-
 use self::backend::error_log::init_error_hooks;
 use self::backend::fetch::{MangadexClient, MANGADEX_CLIENT_INSTANCE};
 use self::backend::filter::Languages;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,13 @@
 #![forbid(unsafe_code)]
 #![allow(dead_code)]
 use std::time::Duration;
+
 use clap::Parser;
 use once_cell::sync::Lazy;
 use ratatui::backend::CrosstermBackend;
 use ratatui_image::picker::{Picker, ProtocolType};
 use reqwest::{Client, StatusCode};
+
 use self::backend::error_log::init_error_hooks;
 use self::backend::fetch::{MangadexClient, MANGADEX_CLIENT_INSTANCE};
 use self::backend::filter::Languages;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 #![allow(dead_code)]
+#![allow(deprecated)]
 use std::time::Duration;
 
 use clap::Parser;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,10 @@
 use std::io::Cursor;
-
 use image::io::Reader;
-use ratatui::prelude::*;
-use ratatui::widgets::*;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Style, Stylize};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Paragraph, Widget};
+use ratatui::Frame;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::task::JoinSet;
 use tui_input::Input;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 use std::io::Cursor;
+
 use image::io::Reader;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Style, Stylize};

--- a/src/view/pages/feed.rs
+++ b/src/view/pages/feed.rs
@@ -1,16 +1,17 @@
 use std::io::Cursor;
-
 use crossterm::event::{KeyCode, KeyEvent, MouseEvent, MouseEventKind};
 use image::io::Reader;
-use ratatui::prelude::*;
-use ratatui::widgets::*;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Layout, Margin, Rect};
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span, ToSpan};
+use ratatui::widgets::{Block, Paragraph, StatefulWidget, Tabs, Widget};
+use ratatui::Frame;
 use throbber_widgets_tui::{Throbber, ThrobberState};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinSet;
 use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
-
-use self::text::ToSpan;
 use crate::backend::database::{get_history, MangaHistoryResponse, MangaHistoryType};
 use crate::backend::error_log::{write_to_error_log, ErrorType};
 use crate::backend::fetch::MangadexClient;
@@ -435,7 +436,7 @@ impl Feed {
 impl Component for Feed {
     type Actions = FeedActions;
 
-    fn render(&mut self, area: ratatui::prelude::Rect, frame: &mut Frame<'_>) {
+    fn render(&mut self, area: Rect, frame: &mut Frame<'_>) {
         let layout = Layout::vertical([Constraint::Percentage(20), Constraint::Percentage(80)]);
 
         let [tabs_area, history_area] = layout.areas(area);

--- a/src/view/pages/feed.rs
+++ b/src/view/pages/feed.rs
@@ -1,4 +1,5 @@
 use std::io::Cursor;
+
 use crossterm::event::{KeyCode, KeyEvent, MouseEvent, MouseEventKind};
 use image::io::Reader;
 use ratatui::buffer::Buffer;
@@ -12,6 +13,7 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinSet;
 use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
+
 use crate::backend::database::{get_history, MangaHistoryResponse, MangaHistoryType};
 use crate::backend::error_log::{write_to_error_log, ErrorType};
 use crate::backend::fetch::MangadexClient;

--- a/src/view/pages/home.rs
+++ b/src/view/pages/home.rs
@@ -1,17 +1,18 @@
 use std::env;
 use std::io::Cursor;
-
 use crossterm::event::{KeyCode, KeyEvent};
 use image::io::Reader;
 use image::DynamicImage;
-use ratatui::prelude::*;
-use ratatui::widgets::*;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Layout, Margin, Rect};
+use ratatui::style::Stylize;
+use ratatui::text::{Line, Span, ToSpan};
+use ratatui::widgets::{Block, List, StatefulWidget, Widget};
+use ratatui::Frame;
 use ratatui_image::protocol::StatefulProtocol;
 use ratatui_image::{Resize, StatefulImage};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinSet;
-
-use self::text::ToSpan;
 use crate::backend::error_log::{write_to_error_log, ErrorType};
 use crate::backend::fetch::MangadexClient;
 use crate::backend::tui::Events;
@@ -78,7 +79,7 @@ pub struct Home {
 impl Component for Home {
     type Actions = HomeActions;
 
-    fn render(&mut self, area: ratatui::prelude::Rect, frame: &mut Frame<'_>) {
+    fn render(&mut self, area: Rect, frame: &mut Frame<'_>) {
         let layout = Layout::vertical([Constraint::Percentage(50), Constraint::Percentage(50)]).margin(1);
         let buf = frame.buffer_mut();
 

--- a/src/view/pages/home.rs
+++ b/src/view/pages/home.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::io::Cursor;
+
 use crossterm::event::{KeyCode, KeyEvent};
 use image::io::Reader;
 use image::DynamicImage;
@@ -13,6 +14,7 @@ use ratatui_image::protocol::StatefulProtocol;
 use ratatui_image::{Resize, StatefulImage};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinSet;
+
 use crate::backend::error_log::{write_to_error_log, ErrorType};
 use crate::backend::fetch::MangadexClient;
 use crate::backend::tui::Events;

--- a/src/view/pages/manga.rs
+++ b/src/view/pages/manga.rs
@@ -1,13 +1,15 @@
 use crossterm::event::{KeyCode, KeyEvent, MouseEvent, MouseEventKind};
-use ratatui::prelude::*;
-use ratatui::widgets::*;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Style, Stylize};
+use ratatui::text::{Line, Span, ToSpan};
+use ratatui::widgets::{Block, Clear, List, ListState, Paragraph, StatefulWidget, Widget, Wrap};
+use ratatui::Frame;
 use ratatui_image::protocol::StatefulProtocol;
 use ratatui_image::{Resize, StatefulImage};
 use strum::Display;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinSet;
-
-use self::text::ToSpan;
 use crate::backend::database::{
     get_chapters_history_status, save_history, set_chapter_downloaded, MangaReadingHistorySave, SetChapterDownloaded,
 };
@@ -915,7 +917,7 @@ impl MangaPage {
 impl Component for MangaPage {
     type Actions = MangaPageActions;
 
-    fn render(&mut self, area: ratatui::prelude::Rect, frame: &mut ratatui::Frame<'_>) {
+    fn render(&mut self, area: Rect, frame: &mut Frame<'_>) {
         let layout = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([Constraint::Percentage(15), Constraint::Percentage(85)]);

--- a/src/view/pages/manga.rs
+++ b/src/view/pages/manga.rs
@@ -10,6 +10,7 @@ use ratatui_image::{Resize, StatefulImage};
 use strum::Display;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinSet;
+
 use crate::backend::database::{
     get_chapters_history_status, save_history, set_chapter_downloaded, MangaReadingHistorySave, SetChapterDownloaded,
 };

--- a/src/view/pages/reader.rs
+++ b/src/view/pages/reader.rs
@@ -1,13 +1,15 @@
 use crossterm::event::KeyCode;
 use image::io::Reader;
 use image::GenericImageView;
-use ratatui::prelude::*;
-use ratatui::widgets::*;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Layout, Margin, Rect};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Paragraph, StatefulWidget, Widget};
+use ratatui::Frame;
 use ratatui_image::protocol::StatefulProtocol;
 use ratatui_image::{Resize, StatefulImage};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinSet;
-
 use crate::backend::error_log::{write_to_error_log, ErrorType};
 use crate::backend::fetch::MangadexClient;
 use crate::backend::tui::Events;
@@ -75,7 +77,7 @@ pub struct MangaReader {
 impl Component for MangaReader {
     type Actions = MangaReaderActions;
 
-    fn render(&mut self, area: ratatui::prelude::Rect, frame: &mut Frame<'_>) {
+    fn render(&mut self, area: Rect, frame: &mut Frame<'_>) {
         let buf = frame.buffer_mut();
 
         let layout = Layout::horizontal([Constraint::Fill(1), Constraint::Fill(self.current_page_size), Constraint::Fill(1)]);

--- a/src/view/pages/reader.rs
+++ b/src/view/pages/reader.rs
@@ -10,6 +10,7 @@ use ratatui_image::protocol::StatefulProtocol;
 use ratatui_image::{Resize, StatefulImage};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinSet;
+
 use crate::backend::error_log::{write_to_error_log, ErrorType};
 use crate::backend::fetch::MangadexClient;
 use crate::backend::tui::Events;

--- a/src/view/pages/search.rs
+++ b/src/view/pages/search.rs
@@ -11,6 +11,7 @@ use tokio::task::JoinSet;
 use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
 use tui_widget_list::ListState;
+
 use crate::backend::database::{save_plan_to_read, MangaPlanToReadSave};
 use crate::backend::error_log::{write_to_error_log, ErrorType};
 use crate::backend::fetch::MangadexClient;

--- a/src/view/pages/search.rs
+++ b/src/view/pages/search.rs
@@ -1,6 +1,9 @@
 use crossterm::event::{self, KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
-use ratatui::prelude::*;
-use ratatui::widgets::*;
+use ratatui::layout::{Constraint, Direction, Layout, Margin, Rect};
+use ratatui::style::{Color, Style, Stylize};
+use ratatui::text::{Line, Span, ToSpan};
+use ratatui::widgets::{Block, Paragraph, StatefulWidget, StatefulWidgetRef, Widget, Wrap};
+use ratatui::Frame;
 use ratatui_image::protocol::StatefulProtocol;
 use throbber_widgets_tui::{Throbber, ThrobberState};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
@@ -8,8 +11,6 @@ use tokio::task::JoinSet;
 use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
 use tui_widget_list::ListState;
-
-use self::text::ToSpan;
 use crate::backend::database::{save_plan_to_read, MangaPlanToReadSave};
 use crate::backend::error_log::{write_to_error_log, ErrorType};
 use crate::backend::fetch::MangadexClient;
@@ -582,6 +583,8 @@ impl SearchPage {
 
 #[cfg(test)]
 mod test {
+    use ratatui::buffer::Buffer;
+
     use super::*;
     use crate::view::widgets::press_key;
 

--- a/src/view/widgets.rs
+++ b/src/view/widgets.rs
@@ -1,4 +1,5 @@
 use crossterm::event::KeyCode;
+use ratatui::layout::Rect;
 use ratatui::Frame;
 use ratatui_image::protocol::StatefulProtocol;
 
@@ -14,7 +15,7 @@ pub mod search;
 pub trait Component {
     type Actions;
     ///Handles the logic for drawing to the screen
-    fn render(&mut self, area: ratatui::prelude::Rect, frame: &mut Frame<'_>);
+    fn render(&mut self, area: Rect, frame: &mut Frame<'_>);
     fn handle_events(&mut self, events: Events);
     fn update(&mut self, action: Self::Actions);
 
@@ -24,7 +25,7 @@ pub trait Component {
 
 pub trait StatefulWidgetFrame {
     type State;
-    fn render(&mut self, area: ratatui::prelude::Rect, frame: &mut Frame<'_>, state: &mut Self::State);
+    fn render(&mut self, area: Rect, frame: &mut Frame<'_>, state: &mut Self::State);
 }
 
 pub trait ImageHandler: Send + 'static {

--- a/src/view/widgets/feed.rs
+++ b/src/view/widgets/feed.rs
@@ -1,9 +1,8 @@
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Layout, Margin, Rect};
 use ratatui::style::{Color, Style, Stylize};
-use ratatui::text::{Line};
+use ratatui::text::Line;
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, StatefulWidget, StatefulWidgetRef, Widget, Wrap};
-
 use tui_widget_list::PreRender;
 
 use crate::backend::filter::Languages;

--- a/src/view/widgets/feed.rs
+++ b/src/view/widgets/feed.rs
@@ -2,7 +2,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Layout, Margin, Rect};
 use ratatui::style::{Color, Style, Stylize};
 use ratatui::text::Line;
-use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, StatefulWidget, StatefulWidgetRef, Widget, Wrap};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, StatefulWidget, Widget, Wrap};
 use tui_widget_list::PreRender;
 
 use crate::backend::filter::Languages;

--- a/src/view/widgets/feed.rs
+++ b/src/view/widgets/feed.rs
@@ -1,5 +1,9 @@
-use ratatui::prelude::*;
-use ratatui::widgets::*;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Layout, Margin, Rect};
+use ratatui::style::{Color, Style, Stylize};
+use ratatui::text::{Line};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, StatefulWidget, StatefulWidgetRef, Widget, Wrap};
+
 use tui_widget_list::PreRender;
 
 use crate::backend::filter::Languages;
@@ -161,7 +165,7 @@ impl HistoryWidget {
 impl StatefulWidget for HistoryWidget {
     type State = tui_widget_list::ListState;
 
-    fn render(mut self, area: ratatui::prelude::Rect, buf: &mut ratatui::prelude::Buffer, state: &mut Self::State) {
+    fn render(mut self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let layout = Layout::vertical([Constraint::Percentage(10), Constraint::Percentage(90)]);
         let [total_results_area, list_area] = layout.areas(area);
 

--- a/src/view/widgets/filter_widget.rs
+++ b/src/view/widgets/filter_widget.rs
@@ -5,6 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Clear, HighlightSpacing, List, ListItem, ListState, Paragraph, StatefulWidget, Tabs, Widget, Wrap};
 use ratatui::Frame;
 use state::*;
+
 use super::StatefulWidgetFrame;
 use crate::global::CURRENT_LIST_ITEM_STYLE;
 use crate::utils::{centered_rect, render_search_bar, set_filter_tags_style};

--- a/src/view/widgets/filter_widget.rs
+++ b/src/view/widgets/filter_widget.rs
@@ -1,7 +1,10 @@
-use ratatui::prelude::*;
-use ratatui::widgets::*;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Style, Stylize};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Clear, HighlightSpacing, List, ListItem, ListState, Paragraph, StatefulWidget, Tabs, Widget, Wrap};
+use ratatui::Frame;
 use state::*;
-
 use super::StatefulWidgetFrame;
 use crate::global::CURRENT_LIST_ITEM_STYLE;
 use crate::utils::{centered_rect, render_search_bar, set_filter_tags_style};
@@ -50,7 +53,7 @@ impl From<TagListItem> for ListItem<'_> {
 impl<'a> StatefulWidgetFrame for FilterWidget<'a> {
     type State = FilterState;
 
-    fn render(&mut self, area: ratatui::prelude::Rect, frame: &mut Frame<'_>, state: &mut Self::State) {
+    fn render(&mut self, area: Rect, frame: &mut Frame<'_>, state: &mut Self::State) {
         let buf = frame.buffer_mut();
         let popup_area = centered_rect(area, 80, 70);
 

--- a/src/view/widgets/home.rs
+++ b/src/view/widgets/home.rs
@@ -1,9 +1,11 @@
-use ratatui::prelude::*;
-use ratatui::widgets::*;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Layout, Margin, Rect};
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Paragraph, StatefulWidget, Widget, Wrap};
 use ratatui_image::protocol::StatefulProtocol;
 use ratatui_image::{Resize, StatefulImage};
 use throbber_widgets_tui::{Throbber, ThrobberState};
-
 use crate::backend::{Data, SearchMangaResponse};
 use crate::common::Manga;
 use crate::utils::{from_manga_response, set_status_style, set_tags_style};
@@ -34,8 +36,8 @@ impl CarrouselItem {
     }
 
     fn render_cover(&mut self, area: Rect, buf: &mut Buffer) {
-        match self.cover_state {
-            Some(ref mut image_state) => {
+        match self.cover_state.as_mut() {
+            Some(image_state) => {
                 let cover = StatefulImage::new(None).resize(Resize::Fit(None));
 
                 StatefulWidget::render(cover, area, buf, image_state)

--- a/src/view/widgets/home.rs
+++ b/src/view/widgets/home.rs
@@ -6,6 +6,7 @@ use ratatui::widgets::{Block, Paragraph, StatefulWidget, Widget, Wrap};
 use ratatui_image::protocol::StatefulProtocol;
 use ratatui_image::{Resize, StatefulImage};
 use throbber_widgets_tui::{Throbber, ThrobberState};
+
 use crate::backend::{Data, SearchMangaResponse};
 use crate::common::Manga;
 use crate::utils::{from_manga_response, set_status_style, set_tags_style};

--- a/src/view/widgets/manga.rs
+++ b/src/view/widgets/manga.rs
@@ -1,12 +1,13 @@
 use std::path::PathBuf;
-
-use ratatui::prelude::*;
-use ratatui::widgets::*;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Layout, Margin, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::symbols::line::THICK;
+use ratatui::text::{Line, ToSpan};
+use ratatui::widgets::{Block, LineGauge, Paragraph, StatefulWidget, Widget, Wrap};
 use throbber_widgets_tui::{Throbber, ThrobberState};
 use tokio::sync::mpsc::UnboundedSender;
 use tui_widget_list::PreRender;
-
-use self::text::ToSpan;
 use crate::backend::filter::Languages;
 use crate::backend::ChapterResponse;
 use crate::global::{CURRENT_LIST_ITEM_STYLE, ERROR_STYLE, INSTRUCTIONS_STYLE};
@@ -69,7 +70,7 @@ impl Widget for ChapterItem {
                 LineGauge::default()
                     .block(Block::bordered().title("Downloading please wait a moment"))
                     .filled_style(Style::default().fg(Color::Blue).bg(Color::Black).add_modifier(Modifier::BOLD))
-                    .line_set(symbols::line::THICK)
+                    .line_set(THICK)
                     .ratio(*progress)
                     .render(scanlator_area, buf);
             },
@@ -442,7 +443,7 @@ impl<'a> StatefulWidget for DownloadAllChaptersWidget<'a> {
                 LineGauge::default()
                     .block(Block::bordered().title(download_progress_title))
                     .filled_style(Style::default().fg(Color::Blue).bg(Color::Black).add_modifier(Modifier::BOLD))
-                    .line_set(symbols::line::THICK)
+                    .line_set(THICK)
                     .ratio(state.download_progress / state.total_chapters)
                     .render(progress_area, buf);
             },

--- a/src/view/widgets/manga.rs
+++ b/src/view/widgets/manga.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Layout, Margin, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -8,6 +9,7 @@ use ratatui::widgets::{Block, LineGauge, Paragraph, StatefulWidget, Widget, Wrap
 use throbber_widgets_tui::{Throbber, ThrobberState};
 use tokio::sync::mpsc::UnboundedSender;
 use tui_widget_list::PreRender;
+
 use crate::backend::filter::Languages;
 use crate::backend::ChapterResponse;
 use crate::global::{CURRENT_LIST_ITEM_STYLE, ERROR_STYLE, INSTRUCTIONS_STYLE};

--- a/src/view/widgets/reader.rs
+++ b/src/view/widgets/reader.rs
@@ -1,5 +1,7 @@
-use ratatui::prelude::*;
-use ratatui::widgets::*;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Style};
+use ratatui::widgets::{Block, Paragraph, StatefulWidget, Widget, Wrap};
 use throbber_widgets_tui::{Throbber, ThrobberState};
 use tui_widget_list::PreRender;
 

--- a/src/view/widgets/search.rs
+++ b/src/view/widgets/search.rs
@@ -1,7 +1,11 @@
-use ratatui::prelude::*;
-use ratatui::widgets::*;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Layout, Margin, Rect};
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Paragraph, StatefulWidget, StatefulWidgetRef, Widget, Wrap};
 use ratatui_image::protocol::StatefulProtocol;
 use ratatui_image::{Resize, StatefulImage};
+
 use throbber_widgets_tui::{Throbber, ThrobberState};
 use tui_widget_list::PreRender;
 
@@ -75,7 +79,7 @@ impl<'a> MangaPreview<'a> {
     pub fn render_description_area(self, area: Rect, buf: &mut Buffer) {
         Block::bordered().title(self.title).render(area, buf);
 
-        let inner = area.inner(layout::Margin {
+        let inner = area.inner(Margin {
             horizontal: 1,
             vertical: 2,
         });
@@ -102,7 +106,7 @@ impl<'a> MangaPreview<'a> {
 impl<'a> StatefulWidget for MangaPreview<'a> {
     type State = Option<Box<dyn StatefulProtocol>>;
 
-    fn render(mut self, area: ratatui::prelude::Rect, buf: &mut Buffer, state: &mut Self::State) {
+    fn render(mut self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let [cover_details_area, description_area] =
             Layout::vertical([Constraint::Percentage(40), Constraint::Percentage(60)]).areas(area);
 
@@ -119,7 +123,7 @@ pub struct MangaItem {
 }
 
 impl Widget for MangaItem {
-    fn render(self, area: ratatui::prelude::Rect, buf: &mut Buffer)
+    fn render(self, area: Rect, buf: &mut Buffer)
     where
         Self: Sized,
     {
@@ -177,7 +181,7 @@ impl ListMangasFoundWidget {
 impl StatefulWidgetRef for ListMangasFoundWidget {
     type State = tui_widget_list::ListState;
 
-    fn render_ref(&self, area: ratatui::prelude::Rect, buf: &mut Buffer, state: &mut Self::State) {
+    fn render_ref(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let list = tui_widget_list::List::new(self.mangas.clone());
         StatefulWidget::render(list, area, buf, state);
     }

--- a/src/view/widgets/search.rs
+++ b/src/view/widgets/search.rs
@@ -5,7 +5,6 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Paragraph, StatefulWidget, StatefulWidgetRef, Widget, Wrap};
 use ratatui_image::protocol::StatefulProtocol;
 use ratatui_image::{Resize, StatefulImage};
-
 use throbber_widgets_tui::{Throbber, ThrobberState};
 use tui_widget_list::PreRender;
 


### PR DESCRIPTION
bump versions of: rataui, crossterm, tui-input, tui-widget-list, throbber-widgets-tui and rataui-image