### PR TITLE
docs: add nix instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ You can install `manga-tui` from the [AUR](https://aur.archlinux.org/packages/ma
 paru -S manga-tui
 ```
 
+### Nix
+
+If you have the [Nix package manager](https://nixos.org/), this repo provides a flake that builds the latest git version from source.
+
+Simply run the following:
+
+```sh
+nix run 'github:josueBarretogit/manga-tui'
+```
+
+Or, to install persistently:
+
+```sh
+nix profile install 'github:josueBarretogit/manga-tui'
+```
+
 ## Binary release
 
 Download a binary from the [releases page](https://github.com/josueBarretogit/manga-tui/releases/latest)


### PR DESCRIPTION
I added a couple brief lines to the README usage section that points out the flake added in #17. This helps Nix users easily test out or install the package with minimal friction.