### PR TITLE
Incremental Page Loading and Reloading

### DIFF
--- a/manga-tui-config.toml
+++ b/manga-tui-config.toml
@@ -1,9 +1,14 @@
 # The format of the manga downloaded 
 # values : cbz , raw, epub 
 # default : cbz 
-download_type = "cbz" 
- 
+download_type = "cbz"
+
 # Download image quality, low quality means images are compressed and is recommended for slow internet connections 
 # values : low, high 
 # default : low 
-image_quality = "low" 
+image_quality = "low"
+
+# Pages around the currently selected page to try to prefetch
+# values : 0-255
+# default : 5
+amount_pages = 5

--- a/src/backend/error_log.rs
+++ b/src/backend/error_log.rs
@@ -14,6 +14,7 @@ use super::AppDirectories;
 pub enum ErrorType<'a> {
     FromPanic(&'a PanicInfo<'a>),
     FromError(Box<dyn Error>),
+    String(&'a str),
 }
 
 fn get_error_logs_path() -> PathBuf {
@@ -34,6 +35,7 @@ pub fn write_to_error_log(e: ErrorType<'_>) {
     let error_format = match e {
         ErrorType::FromPanic(panic_info) => format!("{} | {} | {} \n \n", now, panic_info, panic_info.location().unwrap()),
         ErrorType::FromError(boxed_err) => format!("{} | {} \n \n", now, boxed_err),
+        ErrorType::String(str) => format!("{} | {} \n \n", now, str),
     };
 
     let error_format_bytes = error_format.as_bytes();

--- a/src/backend/error_log.rs
+++ b/src/backend/error_log.rs
@@ -12,8 +12,8 @@ use super::tui::restore;
 use super::AppDirectories;
 
 pub enum ErrorType<'a> {
-    FromPanic(&'a PanicInfo<'a>),
-    FromError(Box<dyn Error>),
+    Panic(&'a PanicInfo<'a>),
+    Error(Box<dyn Error>),
     String(&'a str),
 }
 
@@ -33,8 +33,8 @@ pub fn write_to_error_log(e: ErrorType<'_>) {
     let now = offset::Local::now();
 
     let error_format = match e {
-        ErrorType::FromPanic(panic_info) => format!("{} | {} | {} \n \n", now, panic_info, panic_info.location().unwrap()),
-        ErrorType::FromError(boxed_err) => format!("{} | {} \n \n", now, boxed_err),
+        ErrorType::Panic(panic_info) => format!("{} | {} | {} \n \n", now, panic_info, panic_info.location().unwrap()),
+        ErrorType::Error(boxed_err) => format!("{} | {} \n \n", now, boxed_err),
         ErrorType::String(str) => format!("{} | {} \n \n", now, str),
     };
 
@@ -71,7 +71,7 @@ pub fn init_error_hooks() -> color_eyre::Result<()> {
 
     std::panic::set_hook(Box::new(move |info| {
         let _ = restore();
-        write_to_error_log(ErrorType::FromPanic(info));
+        write_to_error_log(ErrorType::Panic(info));
         panic(info);
     }));
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,11 +35,21 @@ impl ImageQuality {
     }
 }
 
-#[derive(Default, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct MangaTuiConfig {
     pub download_type: DownloadType,
     pub image_quality: ImageQuality,
     pub amount_pages: u8,
+}
+
+impl Default for MangaTuiConfig {
+    fn default() -> Self {
+        Self {
+            amount_pages: 5,
+            download_type: DownloadType::default(),
+            image_quality: ImageQuality::default(),
+        }
+    }
 }
 
 pub static CONFIG: OnceCell<MangaTuiConfig> = OnceCell::new();

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,7 @@ impl ImageQuality {
 pub struct MangaTuiConfig {
     pub download_type: DownloadType,
     pub image_quality: ImageQuality,
+    pub amount_pages: u8,
 }
 
 pub static CONFIG: OnceCell<MangaTuiConfig> = OnceCell::new();

--- a/src/view/app.rs
+++ b/src/view/app.rs
@@ -245,7 +245,7 @@ impl<T: ApiClient + SearchChapter + SearchMangaPanel> App<T> {
         self.feed_page.clean_up();
         self.current_tab = SelectedPage::ReaderTab;
 
-        let manga_reader = MangaReader::new(
+        let mut manga_reader = MangaReader::new(
             chapter_to_read,
             manga_to_read.manga_id,
             self.picker.as_ref().cloned().unwrap(),

--- a/src/view/pages/feed.rs
+++ b/src/view/pages/feed.rs
@@ -313,7 +313,7 @@ impl<T: ApiClient> Feed<T> {
                     tx.send(FeedEvents::LoadHistory(Some(history))).ok();
                 },
                 Err(e) => {
-                    write_to_error_log(ErrorType::FromError(Box::new(e)));
+                    write_to_error_log(ErrorType::Error(Box::new(e)));
                     tx.send(FeedEvents::LoadHistory(None)).ok();
                 },
             }

--- a/src/view/pages/home.rs
+++ b/src/view/pages/home.rs
@@ -330,7 +330,7 @@ impl Home {
                     }
                 },
                 Err(e) => {
-                    write_to_error_log(ErrorType::FromError(Box::new(e)));
+                    write_to_error_log(ErrorType::Error(Box::new(e)));
                     tx.send(HomeEvents::LoadPopularMangas(None)).ok();
                 },
             }
@@ -379,7 +379,7 @@ impl Home {
                     }
                 },
                 Err(e) => {
-                    write_to_error_log(ErrorType::FromError(Box::new(e)));
+                    write_to_error_log(ErrorType::Error(Box::new(e)));
                     tx.send(HomeEvents::LoadRecentlyAddedMangas(None)).ok();
                 },
             }

--- a/src/view/pages/manga.rs
+++ b/src/view/pages/manga.rs
@@ -620,7 +620,7 @@ impl MangaPage {
                                 );
 
                                 if let Err(e) = save_response {
-                                    write_to_error_log(error_log::ErrorType::FromError(Box::new(e)));
+                                    write_to_error_log(error_log::ErrorType::Error(Box::new(e)));
                                 }
 
                                 let config = MangaTuiConfig::get();
@@ -645,7 +645,7 @@ impl MangaPage {
                             }
                         },
                         Err(e) => {
-                            write_to_error_log(error_log::ErrorType::FromError(Box::new(e)));
+                            write_to_error_log(error_log::ErrorType::Error(Box::new(e)));
                             local_tx.send(MangaPageEvents::ReadError(id_chapter)).ok();
                         },
                     }
@@ -705,7 +705,7 @@ impl MangaPage {
                     }
                 },
                 Err(e) => {
-                    write_to_error_log(error_log::ErrorType::FromError(Box::new(e)));
+                    write_to_error_log(error_log::ErrorType::Error(Box::new(e)));
                     tx.send(MangaPageEvents::LoadStatistics(None)).ok();
                 },
             };
@@ -729,7 +729,7 @@ impl MangaPage {
                 }
             },
             Err(e) => {
-                write_to_error_log(error_log::ErrorType::FromError(Box::new(e)));
+                write_to_error_log(error_log::ErrorType::Error(Box::new(e)));
             },
         }
     }
@@ -759,7 +759,7 @@ impl MangaPage {
 
             match database.bookmark(chapter_to_bookmark) {
                 Ok(()) => chapter_selected.is_bookmarked = true,
-                Err(e) => write_to_error_log(ErrorType::FromError(e)),
+                Err(e) => write_to_error_log(ErrorType::Error(e)),
             }
         }
     }
@@ -774,7 +774,7 @@ impl MangaPage {
                     self.bookmark_state = BookMarkState::NotFoundDatabase;
                 },
             },
-            Err(e) => write_to_error_log(ErrorType::FromError(e)),
+            Err(e) => write_to_error_log(ErrorType::Error(e)),
         };
     }
 
@@ -790,7 +790,7 @@ impl MangaPage {
                     sender.send(MangaPageEvents::ReadChapterBookmarked(response.0, response.1)).ok();
                 },
                 Err(e) => {
-                    write_to_error_log(ErrorType::FromError(e));
+                    write_to_error_log(ErrorType::Error(e));
                     sender.send(MangaPageEvents::FetchBookmarkFailed).ok();
                 },
             }
@@ -846,7 +846,7 @@ impl MangaPage {
                         tx.send(MangaPageEvents::ChapterFinishedDownloading(chapter_id)).ok();
                     },
                     Err(e) => {
-                        write_to_error_log(ErrorType::FromError(e));
+                        write_to_error_log(ErrorType::Error(e));
                         tx.send(MangaPageEvents::DownloadError(chapter_id)).ok();
                     },
                 }
@@ -879,7 +879,7 @@ impl MangaPage {
         );
 
         if let Err(e) = save_download_operation {
-            write_to_error_log(error_log::ErrorType::FromError(Box::new(e)));
+            write_to_error_log(error_log::ErrorType::Error(Box::new(e)));
         }
     }
 
@@ -988,7 +988,7 @@ impl MangaPage {
 
             if let Err(e) = download_all_chapters_process {
                 tx.send(MangaPageEvents::DownloadAllChaptersError).ok();
-                write_to_error_log(ErrorType::FromError(e));
+                write_to_error_log(ErrorType::Error(e));
             }
         });
     }

--- a/src/view/pages/reader.rs
+++ b/src/view/pages/reader.rs
@@ -587,6 +587,7 @@ impl<T: SearchChapter + SearchMangaPanel> MangaReader<T> {
         if self.state == State::SearchingChapter {
             self.search_next_chapter_loader.calc_next();
         }
+
         while let Ok(background_event) = self.local_event_rx.try_recv() {
             match background_event {
                 MangaReaderEvents::SaveReadingToDatabase => {

--- a/src/view/pages/reader.rs
+++ b/src/view/pages/reader.rs
@@ -679,7 +679,7 @@ impl<T: SearchChapter + SearchMangaPanel> MangaReader<T> {
                     sender.send(MangaReaderEvents::LoadChapter(res)).ok();
                 },
                 Err(e) => {
-                    write_to_error_log(ErrorType::FromError(e));
+                    write_to_error_log(ErrorType::Error(e));
                     sender.send(MangaReaderEvents::ErrorSearchingChapter).ok();
                 },
             };

--- a/src/view/pages/reader.rs
+++ b/src/view/pages/reader.rs
@@ -1103,8 +1103,18 @@ mod test {
         assert_eq!(MangaReaderActions::PreviousPage, action);
     }
 
-    #[test]
-    fn handle_key_events() {
+    #[tokio::test]
+    async fn correct_initialization() {
+        let mut reader_page = initialize_reader_page(TestApiClient::new());
+
+        let fetch_pages_event = reader_page.local_event_rx.recv().await.expect("the event to fetch pages is not sent");
+
+        assert_eq!(MangaReaderEvents::FetchPages, fetch_pages_event);
+        assert!(!reader_page.pages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn handle_key_events() {
         let mut reader_page = initialize_reader_page(TestApiClient::new());
 
         reader_page.pages_list = PagesList::new(vec![PagesItem::new(0), PagesItem::new(1), PagesItem::new(2)]);

--- a/src/view/pages/search.rs
+++ b/src/view/pages/search.rs
@@ -394,7 +394,7 @@ impl SearchPage {
                 Ok(()) => {
                     self.manga_added_to_plan_to_read = Some(item.manga.title.clone());
                 },
-                Err(e) => write_to_error_log(ErrorType::FromError(Box::new(e))),
+                Err(e) => write_to_error_log(ErrorType::Error(Box::new(e))),
             }
         }
     }

--- a/src/view/tasks/feed.rs
+++ b/src/view/tasks/feed.rs
@@ -24,7 +24,7 @@ pub async fn search_manga<T: ApiClient>(
             }
         },
         Err(e) => {
-            write_to_error_log(ErrorType::FromError(Box::new(e)));
+            write_to_error_log(ErrorType::Error(Box::new(e)));
             feed_page_sender.send(FeedEvents::ErrorSearchingMangaData).ok();
         },
     }
@@ -39,7 +39,7 @@ pub async fn search_latest_chapters<T: ApiClient>(api_client: T, manga_id: Strin
             }
         },
         Err(e) => {
-            write_to_error_log(ErrorType::FromError(Box::new(e)));
+            write_to_error_log(ErrorType::Error(Box::new(e)));
             sender.send(FeedEvents::LoadRecentChapters(manga_id, None)).ok();
         },
     }

--- a/src/view/tasks/manga.rs
+++ b/src/view/tasks/manga.rs
@@ -41,7 +41,7 @@ pub async fn search_chapters_operation(
             }
         },
         Err(e) => {
-            write_to_error_log(ErrorType::FromError(Box::new(e)));
+            write_to_error_log(ErrorType::Error(Box::new(e)));
             tx.send(MangaPageEvents::LoadChapters(None)).ok();
         },
     }
@@ -326,7 +326,7 @@ pub async fn download_all_chapters(
             .await;
 
             if let Err(e) = download_proccess {
-                write_to_error_log(ErrorType::FromError(e));
+                write_to_error_log(ErrorType::Error(e));
             }
 
             download_data.sender.send(MangaPageEvents::SetDownloadAllChaptersProgress).ok();

--- a/src/view/tasks/reader.rs
+++ b/src/view/tasks/reader.rs
@@ -18,11 +18,10 @@ pub async fn get_manga_panel(
                 panel,
                 index: page_index,
             };
-
-            tx.send(MangaReaderEvents::LoadPage(Some(page))).ok();
+            tx.send(MangaReaderEvents::LoadPage(page)).ok();
         },
         Err(e) => {
-            tx.send(MangaReaderEvents::LoadPage(None)).ok();
+            tx.send(MangaReaderEvents::FailedPage(page_index)).ok();
             write_to_error_log(ErrorType::FromError(e));
         },
     }
@@ -61,7 +60,9 @@ mod test {
         let event = rx.recv().await.expect("could not get manga panel");
 
         let page_data = match event {
-            MangaReaderEvents::LoadPage(page_data) => page_data.expect("should load a page"),
+            MangaReaderEvents::FailedPage(_) => panic!("wrong event was sent"),
+            MangaReaderEvents::FetchPages => panic!("wrong event was sent"),
+            MangaReaderEvents::LoadPage(page_data) => page_data,
             _ => panic!("wrong event was sent"),
         };
 

--- a/src/view/tasks/reader.rs
+++ b/src/view/tasks/reader.rs
@@ -22,7 +22,7 @@ pub async fn get_manga_panel(
         },
         Err(e) => {
             tx.send(MangaReaderEvents::FailedPage(page_index)).ok();
-            write_to_error_log(ErrorType::FromError(e));
+            write_to_error_log(ErrorType::Error(e));
         },
     }
 }

--- a/src/view/tasks/search.rs
+++ b/src/view/tasks/search.rs
@@ -23,7 +23,7 @@ pub async fn search_mangas_operation(
             }
         },
         Err(e) => {
-            write_to_error_log(ErrorType::FromError(Box::new(e)));
+            write_to_error_log(ErrorType::Error(Box::new(e)));
             tx.send(SearchPageEvents::LoadMangasFound(None)).ok();
         },
     }


### PR DESCRIPTION
This PR aims to alleviate page failures with incremental fetch requests and allows for a key to reload a page if needed. Would like some input if there's a better way to do this. Should just add parameters to the config file?

Also I noticed that there is significant lag when switching pages, and I'm not sure if it's because of this or running in debug mode.