### PR TITLE
Fix failing nix build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: main
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -46,7 +46,7 @@ jobs:
         with:
           rust-version: nightly-2024-06-25
 
-      - name: check 
+      - name: check
         run: cargo check --locked
 
       - name: build
@@ -58,5 +58,25 @@ jobs:
       - name: test
         run: cargo nextest run --no-fail-fast
 
-      - name: run ignored tests 
+      - name: run ignored tests
         run: cargo nextest run -- --ignored
+
+  build_nix_targets:
+    name: Build Nix targets
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: "write"
+      contents: "read"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check Nix flake inputs
+        uses: DeterminateSystems/flake-checker-action@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v3
+      - name: Activate Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
+
+      - name: Build default package
+        run: nix build

--- a/flake.lock
+++ b/flake.lock
@@ -1,17 +1,12 @@
 {
   "nodes": {
     "crane": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
       "locked": {
-        "lastModified": 1724006180,
-        "narHash": "sha256-PVxPj0Ga2fMYMtcT9ARCthF+4U71YkOT7ZjgD/vf1Aw=",
+        "lastModified": 1730504891,
+        "narHash": "sha256-Fvieht4pai+Wey7terllZAKOj0YsaDP0e88NYs3K/Lo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "7ce92819802bc583b7e82ebc08013a530f22209f",
+        "rev": "8658adcdad49b8f2c6cbf0cc3cb4b4db988f7638",
         "type": "github"
       },
       "original": {
@@ -25,11 +20,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -40,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723991338,
-        "narHash": "sha256-Grh5PF0+gootJfOJFenTTxDTYPidA3V28dqJ/WV7iis=",
+        "lastModified": 1730200266,
+        "narHash": "sha256-l253w0XMT8nWHGXuXqyiIC/bMvh1VRszGXgdpQlfhvU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8a3354191c0d7144db9756a74755672387b702ba",
+        "rev": "807e9154dcb16384b1b765ebe9cd2bba2ac287fd",
         "type": "github"
       },
       "original": {
@@ -69,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724206841,
-        "narHash": "sha256-L8dKaX4T3k+TR2fEHCfGbH4UXdspovz/pj87iai9qmc=",
+        "lastModified": 1730514457,
+        "narHash": "sha256-cjFX208s9pyaOfMvF9xI6WyafyXINqdhMF7b1bMQpLI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "45e98fbd62c32e5927e952d2833fa1ba4fb35a61",
+        "rev": "1ff38ca26eb31858e4dfe7fe738b6b3ce5d74922",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,49 +15,57 @@
   };
 
   outputs =
-    { self
-    , nixpkgs
-    , flake-utils
-    , rust-overlay
-    , crane
-    }:
-    flake-utils.lib.eachDefaultSystem (system:
-    let
-      overlays = [ rust-overlay.overlays.default ];
-      pkgs = import nixpkgs { inherit system overlays; };
-
-      rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
-
-      craneLib = (crane.mkLib nixpkgs.legacyPackages.${system}).overrideToolchain rust;
-
-      commonArgs = {
-        src = craneLib.cleanCargoSource self;
-        strictDeps = true;
-        nativeBuildInputs = with pkgs; [
-          pkg-config
-        ];
-        buildInputs = with pkgs; [
-          openssl
-        ];
-      };
-
-      cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-    in
     {
-      packages = rec {
-        manga-tui = craneLib.buildPackage (commonArgs // {
-          inherit cargoArtifacts;
-        });
+      self,
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+      crane,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        overlays = [ rust-overlay.overlays.default ];
+        pkgs = import nixpkgs { inherit system overlays; };
 
-        default = manga-tui;
-      };
+        rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
 
-      devShells.default = craneLib.devShell {
-        packages = with pkgs; [
-          git
-          openssl
-          pkg-config
-        ];
-      };
-    });
+        craneLib = (crane.mkLib nixpkgs.legacyPackages.${system}).overrideToolchain rust;
+
+        commonArgs = {
+          src = craneLib.cleanCargoSource self;
+          strictDeps = true;
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+          buildInputs = with pkgs; [
+            openssl
+          ];
+        };
+
+        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+      in
+      {
+        packages = rec {
+          manga-tui = craneLib.buildPackage (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+            }
+          );
+
+          default = manga-tui;
+        };
+
+        devShells.default = craneLib.devShell {
+          packages = with pkgs; [
+            git
+            openssl
+            pkg-config
+          ];
+        };
+
+        formatter = pkgs.nixfmt-rfc-style;
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -24,13 +24,18 @@
       let
         overlays = [ rust-overlay.overlays.default ];
         pkgs = import nixpkgs { inherit system overlays; };
+        inherit (pkgs.lib) cleanSource;
 
         rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
 
         craneLib = (crane.mkLib nixpkgs.legacyPackages.${system}).overrideToolchain rust;
 
         commonArgs = {
-          src = craneLib.cleanCargoSource self;
+          # src = craneLib.cleanCargoSource self;
+          #
+          # use regular nixpkgs lib.cleanSource so that `public` directory
+          # isn't removed, causing build failure
+          src = cleanSource self;
           strictDeps = true;
           nativeBuildInputs = with pkgs; [
             pkg-config

--- a/flake.nix
+++ b/flake.nix
@@ -8,10 +8,7 @@
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
   };
 
   outputs =

--- a/src/view/pages/feed.rs
+++ b/src/view/pages/feed.rs
@@ -911,7 +911,7 @@ mod tests {
 
         // Limit the loop to avoid an infinite loop
         let mut counter = 0;
-        let max_ticks = 10;
+        let max_ticks = 1000;
         loop {
             feed_page.tick();
             if feed_page.state == FeedState::MangaPageNotFound || counter >= max_ticks {

--- a/src/view/pages/feed.rs
+++ b/src/view/pages/feed.rs
@@ -901,24 +901,11 @@ mod tests {
 
         let failing_api_client = MockMangadexClient::new().with_returning_errors();
 
-        let mut feed_page: Feed<MockMangadexClient> = Feed::new().with_global_sender(tx).with_api_client(failing_api_client);
+        let mut feed_page: Feed<MockMangadexClient> = Feed::new();
 
-        render_history_and_select(&mut feed_page);
+        search_manga(failing_api_client, "".to_string(), tx, feed_page.local_event_tx.clone()).await;
 
-        feed_page.go_to_manga_page();
-
-        feed_page.tasks.join_next().await;
-
-        // Limit the loop to avoid an infinite loop
-        let mut counter = 0;
-        let max_ticks = 1000;
-        loop {
-            feed_page.tick();
-            if feed_page.state == FeedState::MangaPageNotFound || counter >= max_ticks {
-                break;
-            }
-            counter += 1;
-        }
+        feed_page.tick();
 
         assert_eq!(feed_page.state, FeedState::MangaPageNotFound);
     }


### PR DESCRIPTION
The new release fails to build when using (with both the project's own `flake.nix`, and in `nixpkgs`). This is preventing the update from being pushed into `nixpkgs`.

I fixed a separate issue in the `flake.nix` and tracked down the build failure to the failure of the test `show_error_when_searching_manga`. It passes normally with `cargo test` and `cargo build` but fails in the `nix` sandbox build environment for whatever reason. Increasing `max_ticks` to a much larger number seems to solve the issue but I am not familiar enough with the internals of the codebase and `ratatui` to know if this is a good permanent solution. Feel free to suggest a better fix for this.