### PR TITLE
test(anilist): add test anilist update manga progress

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
         run: cargo build --release --verbose
 
       - name: install cargo nextest
-        run: cargo install cargo-nextest
+        run: cargo install cargo-nextest@0.9.82
 
       - name: test
         run: cargo nextest run --no-fail-fast
@@ -83,6 +83,10 @@ jobs:
         uses: DeterminateSystems/magic-nix-cache-action@main
         with:
           use-flakehub: false
+
+      - name: install_dependencies
+        run: sudo apt install libdbus-1-dev pkg-config
+
 
       - name: Build default package
         run: nix build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
+  RUST_TOOLCHAIN_VERSION : "nightly"
 
 jobs:
   check_code_format_and_lint:
@@ -21,13 +22,18 @@ jobs:
       - name: setup toolchain
         uses: hecrj/setup-rust-action@v1
         with:
-          rust-version: nightly-2024-06-25
+          rust-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
+
+      - name: install_dependencies
+        run: sudo apt install libdbus-1-dev pkg-config
 
       - name: check-fmt
         run: cargo fmt --check
 
       - name: clippy
         run: cargo clippy -- -D warnings
+
+
 
   build_and_test:
     strategy:
@@ -44,7 +50,7 @@ jobs:
       - name: setup toolchain
         uses: hecrj/setup-rust-action@v1
         with:
-          rust-version: nightly-2024-06-25
+          rust-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
 
       - name: check
         run: cargo check --locked

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,10 @@ jobs:
         with:
           rust-version: ${{ env.RUST_TOOLCHAIN_VERSION }}
 
+      - name: Install dependencies (Linux only)
+        if: runner.os == 'Linux'
+        run: sudo apt install libdbus-1-dev pkg-config
+
       - name: check
         run: cargo check --locked
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,16 +760,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
-name = "colored"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
-dependencies = [
- "lazy_static",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "compact_str"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1034,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -1492,6 +1506,15 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -1614,6 +1637,15 @@ dependencies = [
  "similar",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error 1.2.3",
 ]
 
 [[package]]
@@ -2274,6 +2306,7 @@ dependencies = [
  "once_cell",
  "open",
  "pretty_assertions",
+ "pretty_env_logger",
  "ratatui",
  "ratatui-image",
  "reqwest",
@@ -2281,7 +2314,6 @@ dependencies = [
  "rusty-hook",
  "serde",
  "serde_json",
- "simple_logger",
  "strum",
  "strum_macros",
  "throbber-widgets-tui",
@@ -2807,6 +2839,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_env_logger"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+dependencies = [
+ "env_logger",
+ "log",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2842,6 +2884,12 @@ checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -2970,7 +3018,7 @@ dependencies = [
  "avif-serialize",
  "imgref",
  "loop9",
- "quick-error",
+ "quick-error 2.0.1",
  "rav1e",
  "rayon",
  "rgb",
@@ -3364,18 +3412,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
-name = "simple_logger"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c5dfa5e08767553704aa0ffd9d9794d527103c736aba9854773851fd7497eb"
-dependencies = [
- "colored",
- "log",
- "time",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3587,6 +3623,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3644,14 +3689,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde",
  "time-core",
- "time-macros",
 ]
 
 [[package]]
@@ -3659,16 +3702,6 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
-dependencies = [
- "num-conv",
- "time-core",
-]
 
 [[package]]
 name = "tiny-keccak"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,6 +905,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "winapi",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42a16374481d92aed73ae45b1f120207d8e71d24fb89f357fadbd8f946fd84b"
+dependencies = [
+ "dbus",
+ "futures-util",
+ "num",
+ "once_cell",
+ "rand",
+]
+
+[[package]]
 name = "deflate64"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,7 +2126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fa83d1ca02db069b5fbe94b23b584d588e989218310c9c15015bb5571ef1a94"
 dependencies = [
  "byteorder",
- "linux-keyutils",
+ "dbus-secret-service",
  "security-framework",
  "windows-sys 0.59.0",
 ]
@@ -2172,6 +2196,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libfuzzer-sys"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2201,16 +2234,6 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "linux-keyutils"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761e49ec5fd8a5a463f9b84e877c373d888935b71c6be78f3767fe2ae6bed18e"
-dependencies = [
- "bitflags 2.5.0",
- "libc",
 ]
 
 [[package]]
@@ -2423,12 +2446,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -2455,6 +2501,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,30 +901,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "dbus"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
-dependencies = [
- "libc",
- "libdbus-sys",
- "winapi",
-]
-
-[[package]]
-name = "dbus-secret-service"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42a16374481d92aed73ae45b1f120207d8e71d24fb89f357fadbd8f946fd84b"
-dependencies = [
- "dbus",
- "futures-util",
- "num",
- "once_cell",
- "rand",
 ]
 
 [[package]]
@@ -2084,7 +2070,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fa83d1ca02db069b5fbe94b23b584d588e989218310c9c15015bb5571ef1a94"
 dependencies = [
  "byteorder",
- "dbus-secret-service",
+ "linux-keyutils",
  "security-framework",
  "windows-sys 0.59.0",
 ]
@@ -2154,15 +2140,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
-name = "libdbus-sys"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
-dependencies = [
- "pkg-config",
-]
-
-[[package]]
 name = "libfuzzer-sys"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,6 +2169,16 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761e49ec5fd8a5a463f9b84e877c373d888935b71c6be78f3767fe2ae6bed18e"
+dependencies = [
+ "bitflags 2.5.0",
+ "libc",
 ]
 
 [[package]]
@@ -2234,6 +2221,7 @@ version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 dependencies = [
+ "serde",
  "value-bag",
 ]
 
@@ -2282,6 +2270,7 @@ dependencies = [
  "httpmock",
  "image",
  "keyring",
+ "log",
  "once_cell",
  "open",
  "pretty_assertions",
@@ -2292,6 +2281,7 @@ dependencies = [
  "rusty-hook",
  "serde",
  "serde_json",
+ "simple_logger",
  "strum",
  "strum_macros",
  "throbber-widgets-tui",
@@ -2401,35 +2391,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
 dependencies = [
  "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
  "num-traits",
 ]
 
@@ -2456,17 +2423,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -3408,6 +3364,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
+name = "simple_logger"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c5dfa5e08767553704aa0ffd9d9794d527103c736aba9854773851fd7497eb"
+dependencies = [
+ "colored",
+ "log",
+ "time",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3676,12 +3644,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -3689,6 +3659,16 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tiny-keccak"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,6 +894,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "winapi",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42a16374481d92aed73ae45b1f120207d8e71d24fb89f357fadbd8f946fd84b"
+dependencies = [
+ "dbus",
+ "futures-util",
+ "num",
+ "once_cell",
+ "rand",
+]
+
+[[package]]
 name = "deflate64"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2054,6 +2078,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa83d1ca02db069b5fbe94b23b584d588e989218310c9c15015bb5571ef1a94"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "security-framework",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,6 +2152,15 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2236,6 +2281,7 @@ dependencies = [
  "http 1.1.0",
  "httpmock",
  "image",
+ "keyring",
  "once_cell",
  "open",
  "pretty_assertions",
@@ -2355,12 +2401,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -2387,6 +2456,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ zip = "2.1.6"
 toml = "0.8.19"
 epub-builder = "0.7.4"
 http = "1.0"
-keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
+keyring = { version = "3", features = ["apple-native", "windows-native",  "sync-secret-service"] }
 log = { version = "0.4", features = ["std", "serde"] }
 pretty_env_logger = "0.4" 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ zip = "2.1.6"
 toml = "0.8.19"
 epub-builder = "0.7.4"
 http = "1.0"
+keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 
 [dev-dependencies]
 httpmock = "0.7.0-rc.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,9 @@ zip = "2.1.6"
 toml = "0.8.19"
 epub-builder = "0.7.4"
 http = "1.0"
-keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
+keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
+log = { version = "0.4", features = ["std", "serde"] }
+simple_logger = "5.0.0"
 
 [dev-dependencies]
 httpmock = "0.7.0-rc.1"
@@ -53,4 +55,3 @@ fake = "2.10.0"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_System_Console", "Win32_UI_HiDpi"]}
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ clap = { version = "4.5.18", features = ["derive", "cargo"] }
 zip = "2.1.6"
 toml = "0.8.19"
 epub-builder = "0.7.4"
+http = "1.0"
 
 [dev-dependencies]
 httpmock = "0.7.0-rc.1"
@@ -48,7 +49,6 @@ pretty_assertions = "1.4.0"
 rusty-hook = "0.11.2"
 uuid = { version = "1.10.0", features = ["v4", "fast-rng"] }
 fake = "2.10.0"
-http = "1.0"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_System_Console", "Win32_UI_HiDpi"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ epub-builder = "0.7.4"
 http = "1.0"
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
 log = { version = "0.4", features = ["std", "serde"] }
-simple_logger = "5.0.0"
+pretty_env_logger = "0.4" 
 
 [dev-dependencies]
 httpmock = "0.7.0-rc.1"

--- a/manga-tui-config.toml
+++ b/manga-tui-config.toml
@@ -17,3 +17,8 @@ amount_pages = 5
 # values : true, false
 # default : true
 auto_bookmark = true
+
+# Whether or not downloading a manga counts as reading it on services like anilist
+# values : true, false
+# default : false
+track_reading_when_download = false

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -15,6 +15,7 @@ pub mod error_log;
 pub mod fetch;
 pub mod filter;
 pub mod migration;
+pub mod tracker;
 pub mod tui;
 
 #[derive(Display, EnumIter)]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -15,6 +15,7 @@ pub mod error_log;
 pub mod fetch;
 pub mod filter;
 pub mod migration;
+pub mod secrets;
 pub mod tracker;
 pub mod tui;
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -15,6 +15,7 @@ pub mod error_log;
 pub mod fetch;
 pub mod filter;
 pub mod migration;
+pub mod release_notifier;
 pub mod secrets;
 pub mod tracker;
 pub mod tui;

--- a/src/backend/error_log.rs
+++ b/src/backend/error_log.rs
@@ -23,6 +23,12 @@ impl<'a> From<Box<dyn Error>> for ErrorType<'a> {
     }
 }
 
+impl<'a> From<String> for ErrorType<'a> {
+    fn from(value: String) -> Self {
+        Self::Error(value.into())
+    }
+}
+
 fn get_error_logs_path() -> PathBuf {
     let path = AppDirectories::ErrorLogs.get_base_directory();
 

--- a/src/backend/error_log.rs
+++ b/src/backend/error_log.rs
@@ -17,6 +17,12 @@ pub enum ErrorType<'a> {
     String(&'a str),
 }
 
+impl<'a> From<Box<dyn Error>> for ErrorType<'a> {
+    fn from(value: Box<dyn Error>) -> Self {
+        Self::Error(value)
+    }
+}
+
 fn get_error_logs_path() -> PathBuf {
     let path = AppDirectories::ErrorLogs.get_base_directory();
 

--- a/src/backend/fetch.rs
+++ b/src/backend/fetch.rs
@@ -15,6 +15,7 @@ use super::filter::Languages;
 use crate::backend::api_responses::OneChapterResponse;
 use crate::backend::filter::{Filters, IntoParam};
 use crate::config::ImageQuality;
+use crate::global::USER_AGENT;
 use crate::view::app::MangaToRead;
 use crate::view::pages::manga::{ChapterOrder, FetchChapterBookmarked};
 use crate::view::pages::reader::{ChapterToRead, ListOfChapters, MangaPanel, SearchChapter, SearchMangaPanel};
@@ -96,16 +97,9 @@ impl MangadexClient {
     }
 
     pub fn new(api_url_base: Url, cover_img_url_base: Url) -> Self {
-        let user_agent = format!(
-            "manga-tui/{} ({}/{}/{})",
-            env!("CARGO_PKG_VERSION"),
-            std::env::consts::FAMILY,
-            std::env::consts::OS,
-            std::env::consts::ARCH
-        );
         let client = Client::builder()
             .timeout(StdDuration::from_secs(10))
-            .user_agent(user_agent)
+            .user_agent(&*USER_AGENT)
             .build()
             .unwrap();
 

--- a/src/backend/release_notifier.rs
+++ b/src/backend/release_notifier.rs
@@ -1,0 +1,144 @@
+use std::error::Error;
+use std::time::Duration;
+
+use http::header::ACCEPT;
+use http::{HeaderMap, HeaderValue, StatusCode};
+use reqwest::{Client, Url};
+use serde_json::Value;
+
+use crate::global::USER_AGENT;
+use crate::logger::ILogger;
+
+#[derive(Debug)]
+pub struct ReleaseNotifier {
+    github_url: Url,
+    client: Client,
+}
+
+pub static GITHUB_URL: &str = "https://api.github.com/repos/josueBarretogit/manga-tui";
+
+impl ReleaseNotifier {
+    pub fn new(github_url: Url) -> Self {
+        let mut default_headers = HeaderMap::new();
+
+        default_headers.insert("X-GitHub-Api-Version", HeaderValue::from_static("2022-11-28"));
+        default_headers.insert(ACCEPT, HeaderValue::from_static("application/vnd.github+json"));
+
+        let client = Client::builder()
+            .timeout(Duration::from_secs(10))
+            .default_headers(default_headers)
+            .user_agent(&*USER_AGENT)
+            .build()
+            .unwrap();
+
+        Self { github_url, client }
+    }
+
+    async fn get_latest_release(&self) -> Result<String, Box<dyn Error>> {
+        let endpoint = format!("{}/releases/latest", self.github_url);
+
+        let response = self.client.get(endpoint).send().await?;
+
+        if response.status() != StatusCode::OK {
+            return Err(format!(
+                "could not retrieve latest manga-tui version, more details about the api response : \n {:#?} ",
+                response
+            )
+            .into());
+        }
+
+        let response: Value = response.json().await?;
+
+        let response = response.get("name").cloned().unwrap();
+
+        Ok(response.as_str().unwrap().to_string())
+    }
+
+    /// returns `true` if there is a new version
+    fn new_version(&self, latest: &str, current: &str) -> bool {
+        latest != current
+    }
+
+    pub async fn check_new_releases(self, logger: &impl ILogger) -> Result<(), Box<dyn Error>> {
+        logger.inform("Checking for updates");
+
+        let latest_release = self.get_latest_release().await?;
+        let current_version = format!("v{}", env!("CARGO_PKG_VERSION"));
+
+        if self.new_version(&latest_release, &current_version) {
+            let github_url = format!("https://github.com/josueBarretogit/manga-tui/releases/tag/{latest_release}");
+            logger.inform(format!("There is a new version : {latest_release} to update go to the releases page: {github_url} "));
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        } else {
+            logger.inform("Up to date");
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::Method::GET;
+    use httpmock::MockServer;
+    use pretty_assertions::assert_str_eq;
+    use serde_json::json;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn it_get_latest_version_from_github() -> Result<(), Box<dyn Error>> {
+        let server = MockServer::start_async().await;
+        let notifier = ReleaseNotifier::new(server.base_url().parse()?);
+
+        let release = "v0.4.0";
+
+        println!("{release}");
+        let request = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .header("X-GitHub-Api-Version", "2022-11-28")
+                    .header("Accept", "application/vnd.github+json")
+                    .header("User-Agent", &*USER_AGENT)
+                    .path_contains("releases/latest");
+                then.status(200).json_body(json!({ "name" : release }));
+            })
+            .await;
+
+        let latest_release = notifier.get_latest_release().await?;
+
+        request.assert_async().await;
+
+        assert_str_eq!(release, latest_release);
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_compares_latest_version_from_current_version() -> Result<(), Box<dyn Error>> {
+        let notifier = ReleaseNotifier::new("http:/localhost".parse()?);
+
+        let latest_version = "v0.5.0";
+        let current = "v0.4.0";
+
+        let new_version = notifier.new_version(latest_version, current);
+
+        assert!(new_version);
+
+        let latest_version = "v1.5.0";
+        let current = "v0.4.2";
+
+        let new_version = notifier.new_version(latest_version, current);
+
+        assert!(new_version);
+
+        let latest_version = "v1.5.0";
+        let current = "v1.5.0";
+
+        let new_version = notifier.new_version(latest_version, current);
+
+        assert!(!new_version);
+
+        Ok(())
+    }
+}

--- a/src/backend/secrets.rs
+++ b/src/backend/secrets.rs
@@ -1,0 +1,8 @@
+pub mod anilist;
+
+use std::error::Error;
+
+//pub trait SecretStorage {
+//    fn set_secret(&self, secret_in_bytes: &[u8]) -> Result<(), Box<dyn Error>>;
+//    fn get_secret(self) -> Result<String, Box<dyn Error>>;
+//}

--- a/src/backend/secrets.rs
+++ b/src/backend/secrets.rs
@@ -1,8 +1,13 @@
 pub mod anilist;
 
+use std::collections::HashMap;
 use std::error::Error;
 
-//pub trait SecretStorage {
-//    fn set_secret(&self, secret_in_bytes: &[u8]) -> Result<(), Box<dyn Error>>;
-//    fn get_secret(self) -> Result<String, Box<dyn Error>>;
-//}
+/// Abstraction of the location where secrets will be stored
+pub trait SecretStorage {
+    fn save_secret<T: Into<String>>(&mut self, secret_name: T, value: T) -> Result<(), Box<dyn Error>>;
+    fn save_multiple_secrets<T: Into<String>>(&mut self, values: HashMap<T, T>) -> Result<(), Box<dyn Error>>;
+    fn get_secret<T: Into<String>>(&self, _secret_name: T) -> Result<Option<String>, Box<dyn Error>> {
+        Err("not implemented".into())
+    }
+}

--- a/src/backend/secrets.rs
+++ b/src/backend/secrets.rs
@@ -6,8 +6,38 @@ use std::error::Error;
 /// Abstraction of the location where secrets will be stored
 pub trait SecretStorage {
     fn save_secret<T: Into<String>>(&mut self, secret_name: T, value: T) -> Result<(), Box<dyn Error>>;
-    fn save_multiple_secrets<T: Into<String>>(&mut self, values: HashMap<T, T>) -> Result<(), Box<dyn Error>>;
-    fn get_secret<T: Into<String>>(&self, _secret_name: T) -> Result<Option<String>, Box<dyn Error>> {
-        Err("not implemented".into())
+
+    fn save_multiple_secrets<T: Into<String>>(&mut self, values: HashMap<T, T>) -> Result<(), Box<dyn Error>> {
+        for (name, value) in values {
+            self.save_secret(name, value)?
+        }
+        Ok(())
     }
+
+    fn remove_multiple_secrets<T: AsRef<str>>(&mut self, values: impl Iterator<Item = T>) -> Result<(), Box<dyn Error>> {
+        for name in values {
+            self.remove_secret(name)?
+        }
+        Ok(())
+    }
+
+    fn get_multiple_secrets<T: Into<String>>(
+        &self,
+        secrets_names: impl Iterator<Item = T>,
+    ) -> Result<HashMap<String, String>, Box<dyn Error>> {
+        let mut secrets_collected: HashMap<String, String> = HashMap::new();
+
+        for secrets in secrets_names {
+            let secret_to_find: String = secrets.into();
+            if let Some(secret) = self.get_secret(secret_to_find.clone())? {
+                secrets_collected.insert(secret_to_find, secret);
+            }
+        }
+
+        Ok(secrets_collected)
+    }
+
+    fn get_secret<T: Into<String>>(&self, _secret_name: T) -> Result<Option<String>, Box<dyn Error>>;
+
+    fn remove_secret<T: AsRef<str>>(&mut self, secret_name: T) -> Result<(), Box<dyn Error>>;
 }

--- a/src/backend/secrets/anilist.rs
+++ b/src/backend/secrets/anilist.rs
@@ -4,12 +4,12 @@ use keyring::Entry;
 use super::SecretStorage;
 
 #[derive(Debug)]
-struct AnilistStorage {
+pub struct AnilistStorage {
     service_name: &'static str,
 }
 
 impl AnilistStorage {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             service_name: crate_name!(),
         }
@@ -37,13 +37,11 @@ impl SecretStorage for AnilistStorage {
         }
     }
 
-    fn save_multiple_secrets<T: Into<String>>(
-        &mut self,
-        values: std::collections::HashMap<T, T>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        for (name, value) in values {
-            self.save_secret(name, value)?
-        }
+    fn remove_secret<T: AsRef<str>>(&mut self, secret_name: T) -> Result<(), Box<dyn std::error::Error>> {
+        let secret = Entry::new(self.service_name, secret_name.as_ref())?;
+
+        secret.delete_credential()?;
+
         Ok(())
     }
 }

--- a/src/backend/secrets/anilist.rs
+++ b/src/backend/secrets/anilist.rs
@@ -1,0 +1,25 @@
+#[cfg(test)]
+mod tests {
+    use clap::crate_name;
+    use uuid::Uuid;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct AnilistStorage;
+
+    //#[test]
+    //fn it_stores_anilist_account_secrets() {
+    //    let id = Uuid::new_v4().to_string();
+    //    let code = Uuid::new_v4().to_string();
+    //    let secret = Uuid::new_v4().to_string();
+    //
+    //    AnilistStorage::store(id, code, secret);
+    //
+    //    let (id_stored, code_stored, secret_stored) = AnilistStorage::get_credentials();
+    //
+    //    assert_eq!(id, id_stored);
+    //    assert_eq!(code, code_stored);
+    //    assert_eq!(secret, secret_stored);
+    //}
+}

--- a/src/backend/secrets/anilist.rs
+++ b/src/backend/secrets/anilist.rs
@@ -1,25 +1,87 @@
+use clap::crate_name;
+use keyring::Entry;
+
+use super::SecretStorage;
+
+#[derive(Debug)]
+struct AnilistStorage {
+    service_name: &'static str,
+}
+
+impl AnilistStorage {
+    fn new() -> Self {
+        Self {
+            service_name: crate_name!(),
+        }
+    }
+}
+
+impl SecretStorage for AnilistStorage {
+    fn save_secret<T: Into<String>>(&mut self, secret_name: T, value: T) -> Result<(), Box<dyn std::error::Error>> {
+        let secret = Entry::new(self.service_name, &secret_name.into())?;
+
+        let secret_as_string: String = value.into();
+
+        secret.set_secret(secret_as_string.as_bytes())?;
+
+        Ok(())
+    }
+
+    fn get_secret<T: Into<String>>(&self, secret_name: T) -> Result<Option<String>, Box<dyn std::error::Error>> {
+        let secret = Entry::new(self.service_name, &secret_name.into())?;
+
+        match secret.get_secret() {
+            Ok(secret_as_bytes) => Ok(Some(String::from_utf8(secret_as_bytes)?)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(Box::new(e)),
+        }
+    }
+
+    fn save_multiple_secrets<T: Into<String>>(
+        &mut self,
+        values: std::collections::HashMap<T, T>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        for (name, value) in values {
+            self.save_secret(name, value)?
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use clap::crate_name;
+    use std::collections::HashMap;
+    use std::error::Error;
+
     use uuid::Uuid;
 
     use super::*;
 
-    #[derive(Debug)]
-    struct AnilistStorage;
+    #[test]
+    fn it_stores_anilist_account_secrets() -> Result<(), Box<dyn Error>> {
+        let id = Uuid::new_v4().to_string();
+        let code = Uuid::new_v4().to_string();
+        let secret = Uuid::new_v4().to_string();
 
-    //#[test]
-    //fn it_stores_anilist_account_secrets() {
-    //    let id = Uuid::new_v4().to_string();
-    //    let code = Uuid::new_v4().to_string();
-    //    let secret = Uuid::new_v4().to_string();
-    //
-    //    AnilistStorage::store(id, code, secret);
-    //
-    //    let (id_stored, code_stored, secret_stored) = AnilistStorage::get_credentials();
-    //
-    //    assert_eq!(id, id_stored);
-    //    assert_eq!(code, code_stored);
-    //    assert_eq!(secret, secret_stored);
-    //}
+        let mut anilist_storage = AnilistStorage::new();
+
+        anilist_storage
+            .save_multiple_secrets(HashMap::from([
+                ("id".to_string(), id.clone()),
+                ("code".to_string(), code.clone()),
+                ("secret".to_string(), secret.clone()),
+            ]))
+            .unwrap();
+
+        let id_stored = anilist_storage.get_secret("id")?.unwrap();
+        assert_eq!(id_stored, id);
+
+        let code_stored = anilist_storage.get_secret("code")?.unwrap();
+        assert_eq!(code_stored, code);
+
+        let secret_stored = anilist_storage.get_secret("secret")?.unwrap();
+        assert_eq!(secret_stored, secret);
+
+        Ok(())
+    }
 }

--- a/src/backend/secrets/anilist.rs
+++ b/src/backend/secrets/anilist.rs
@@ -42,7 +42,7 @@ impl AnilistStorage {
         }
     }
 
-    pub fn anilist_check_credentials_stored(&self) -> Result<Option<Credentials>, Box<dyn Error>> {
+    pub fn check_credentials_stored(&self) -> Result<Option<Credentials>, Box<dyn Error>> {
         let credentials = self.get_multiple_secrets([AnilistCredentials::ClientId, AnilistCredentials::AccessToken].into_iter())?;
 
         let client_id = credentials.get(&AnilistCredentials::ClientId.to_string()).cloned();
@@ -96,70 +96,47 @@ impl SecretStorage for AnilistStorage {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use std::error::Error;
-
-    use uuid::Uuid;
-
-    use super::*;
-
-    #[test]
-    fn it_stores_anilist_account_secrets() -> Result<(), Box<dyn Error>> {
-        let id = Uuid::new_v4().to_string();
-        let code = Uuid::new_v4().to_string();
-        let secret = Uuid::new_v4().to_string();
-
-        let mut anilist_storage = AnilistStorage::new();
-
-        anilist_storage
-            .save_multiple_secrets(HashMap::from([
-                ("id".to_string(), id.clone()),
-                ("code".to_string(), code.clone()),
-                ("secret".to_string(), secret.clone()),
-            ]))
-            .unwrap();
-
-        let id_stored = anilist_storage.get_secret("id")?.unwrap();
-        assert_eq!(id_stored, id);
-
-        let code_stored = anilist_storage.get_secret("code")?.unwrap();
-        assert_eq!(code_stored, code);
-
-        let secret_stored = anilist_storage.get_secret("secret")?.unwrap();
-        assert_eq!(secret_stored, secret);
-
-        Ok(())
-    }
+    //use std::collections::HashMap;
+    //use std::error::Error;
+    //
+    //use super::*;
+    //
+    // commented out because dont know how to mock keyring's functionality itself
 
     //#[test]
-    //fn it_checks_anilist_credentials_are_stored() -> Result<(), Box<dyn Error>> {
-    //    let cli = CliArgs::new();
+    //fn it_stores_anilist_account_secrets() -> Result<(), Box<dyn Error>> {
+    //    let id = "some_string".to_string();
+    //    let code = "some_string".to_string();
+    //    let secret = "some_string".to_string();
     //
-    //    let mut storage = MockStorage::default();
+    //    let mut anilist_storage = AnilistStorage::new();
     //
-    //    let not_stored = cli.anilist_check_credentials_stored(&storage)?;
+    //    anilist_storage.save_multiple_secrets(HashMap::from([
+    //        ("id".to_string(), id.clone()),
+    //        ("code".to_string(), code.clone()),
+    //        ("secret".to_string(), secret.clone()),
+    //    ]))?;
     //
-    //    assert!(not_stored.is_none());
+    //    let id_stored = anilist_storage.get_secret("id")?.unwrap();
+    //    assert_eq!(id_stored, id);
     //
-    //    storage.secrets_stored.insert(AnilistCredentials::AccessToken.to_string(), "".to_string());
+    //    let code_stored = anilist_storage.get_secret("code")?.unwrap();
+    //    assert_eq!(code_stored, code);
     //
-    //    storage.secrets_stored.insert(AnilistCredentials::ClientId.to_string(), "".to_string());
+    //    let secret_stored = anilist_storage.get_secret("secret")?.unwrap();
+    //    assert_eq!(secret_stored, secret);
     //
-    //    let stored_but_empty = cli.anilist_check_credentials_stored(&storage)?;
+    //    Ok(())
+    //}
+
+    //#[test]
+    //fn it_retrieves_anilist_credential() -> Result<(), Box<dyn Error>> {
+    //    set_default_credential_builder(mock::default_credential_builder());
+    //    let anilist_storage = AnilistStorage::new();
     //
-    //    assert!(stored_but_empty.is_none());
+    //    let should_be_empty = anilist_storage.check_credentials_stored()?;
     //
-    //    storage
-    //        .secrets_stored
-    //        .insert(AnilistCredentials::AccessToken.to_string(), "some_access_token".to_string());
-    //
-    //    storage
-    //        .secrets_stored
-    //        .insert(AnilistCredentials::ClientId.to_string(), "some_client_id".to_string());
-    //
-    //    let stored = cli.anilist_check_credentials_stored(&storage)?;
-    //
-    //    assert!(stored.is_some_and(|credentials| credentials.access_token == "some_access_token"));
+    //    assert!(should_be_empty.is_none());
     //
     //    Ok(())
     //}

--- a/src/backend/tracker.rs
+++ b/src/backend/tracker.rs
@@ -35,7 +35,7 @@ pub async fn update_reading_progress(
     manga_title: SearchTerm,
     chapter_number: u32,
     volume_number: Option<u32>,
-    tracker: impl MangaTracker + Send,
+    tracker: impl MangaTracker,
 ) -> Result<(), Box<dyn Error>> {
     let response = tracker.search_manga_by_title(manga_title).await?;
     if let Some(manga) = response {
@@ -53,7 +53,7 @@ pub async fn update_reading_progress(
 pub fn track_manga<T, F>(tracker: Option<T>, manga_title: String, chapter_number: u32, volume_number: Option<u32>, on_error: F)
 where
     T: MangaTracker,
-    F: Fn(String) -> () + Send + 'static,
+    F: Fn(String) + Send + 'static,
 {
     if let Some(tracker) = tracker {
         tokio::spawn(async move {

--- a/src/backend/tracker.rs
+++ b/src/backend/tracker.rs
@@ -30,3 +30,40 @@ pub trait MangaTracker: Send + Clone + 'static {
         manga: MarkAsRead<'_>,
     ) -> impl Future<Output = Result<(), Box<dyn Error>>> + Send;
 }
+
+pub async fn update_reading_progress(
+    manga_title: SearchTerm,
+    chapter_number: u32,
+    volume_number: Option<u32>,
+    tracker: impl MangaTracker + Send,
+) -> Result<(), Box<dyn Error>> {
+    let response = tracker.search_manga_by_title(manga_title).await?;
+    if let Some(manga) = response {
+        tracker
+            .mark_manga_as_read_with_chapter_count(MarkAsRead {
+                id: &manga.id,
+                chapter_number,
+                volume_number,
+            })
+            .await?;
+    }
+    Ok(())
+}
+
+pub fn track_manga<T, F>(tracker: Option<T>, manga_title: String, chapter_number: u32, volume_number: Option<u32>, on_error: F)
+where
+    T: MangaTracker,
+    F: Fn(String) -> () + Send + 'static,
+{
+    if let Some(tracker) = tracker {
+        tokio::spawn(async move {
+            let title = SearchTerm::trimmed(&manga_title);
+            if let Some(search_term) = title {
+                let response = update_reading_progress(search_term, chapter_number, volume_number, tracker).await;
+                if let Err(e) = response {
+                    on_error(e.to_string());
+                }
+            }
+        });
+    }
+}

--- a/src/backend/tracker.rs
+++ b/src/backend/tracker.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 use futures::Future;
 use manga_tui::SearchTerm;
 use serde::{Deserialize, Serialize};
@@ -26,5 +28,10 @@ pub trait MangaTracker {
     fn mark_manga_as_read_with_chapter_count(
         &self,
         manga: MarkAsRead<'_>,
-    ) -> impl Future<Output = Result<(), Box<dyn std::error::Error>>> + Send;
+    ) -> impl Future<Output = Result<(), Box<dyn Error>>> + Send;
+
+    /// Used for the user to check wether or not the api key  provided is valid
+    fn verify_authentication(&self) -> impl Future<Output = Result<bool, Box<dyn Error>>> + Send {
+        async { Ok(false) }
+    }
 }

--- a/src/backend/tracker.rs
+++ b/src/backend/tracker.rs
@@ -18,7 +18,7 @@ pub struct MarkAsRead<'a> {
     pub volume_number: Option<u32>,
 }
 
-pub trait MangaTracker {
+pub trait MangaTracker: Send + Clone + 'static {
     fn search_manga_by_title(
         &self,
         title: SearchTerm,
@@ -29,9 +29,4 @@ pub trait MangaTracker {
         &self,
         manga: MarkAsRead<'_>,
     ) -> impl Future<Output = Result<(), Box<dyn Error>>> + Send;
-
-    /// Used for the user to check wether or not the api key  provided is valid
-    fn verify_authentication(&self) -> impl Future<Output = Result<bool, Box<dyn Error>>> + Send {
-        async { Ok(false) }
-    }
 }

--- a/src/backend/tracker.rs
+++ b/src/backend/tracker.rs
@@ -1,0 +1,30 @@
+use futures::Future;
+use manga_tui::SearchTerm;
+use serde::{Deserialize, Serialize};
+
+pub mod anilist;
+
+#[derive(Debug, Deserialize, Serialize, Default, PartialEq, Eq)]
+pub struct MangaToTrack {
+    pub id: String,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct MarkAsRead<'a> {
+    pub id: &'a str,
+    pub chapter_number: u32,
+    pub volume_number: Option<u32>,
+}
+
+pub trait MangaTracker {
+    fn search_manga_by_title(
+        &self,
+        title: SearchTerm,
+    ) -> impl Future<Output = Result<Option<MangaToTrack>, Box<dyn std::error::Error>>> + Send;
+
+    /// Implementors may require api key / account token in order to perform this operation
+    fn mark_manga_as_read_with_chapter_count(
+        &self,
+        manga: MarkAsRead<'_>,
+    ) -> impl Future<Output = Result<(), Box<dyn std::error::Error>>> + Send;
+}

--- a/src/backend/tracker.rs
+++ b/src/backend/tracker.rs
@@ -18,6 +18,11 @@ pub struct MarkAsRead<'a> {
     pub volume_number: Option<u32>,
 }
 
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct PlanToReadArgs<'a> {
+    pub id: &'a str,
+}
+
 pub trait MangaTracker: Send + Clone + 'static {
     fn search_manga_by_title(
         &self,
@@ -29,9 +34,15 @@ pub trait MangaTracker: Send + Clone + 'static {
         &self,
         manga: MarkAsRead<'_>,
     ) -> impl Future<Output = Result<(), Box<dyn Error>>> + Send;
+
+    /// Implementors may require api key / account token in order to perform this operation
+    fn mark_manga_as_plan_to_read(
+        &self,
+        manga_to_plan_to_read: PlanToReadArgs<'_>,
+    ) -> impl Future<Output = Result<(), Box<dyn Error>>> + Send;
 }
 
-pub async fn update_reading_progress(
+async fn update_reading_progress(
     manga_title: SearchTerm,
     chapter_number: u32,
     volume_number: Option<u32>,
@@ -50,6 +61,14 @@ pub async fn update_reading_progress(
     Ok(())
 }
 
+async fn update_plan_to_read(manga_title: SearchTerm, tracker: impl MangaTracker) -> Result<(), Box<dyn Error>> {
+    let response = tracker.search_manga_by_title(manga_title).await?;
+    if let Some(manga) = response {
+        tracker.mark_manga_as_plan_to_read(PlanToReadArgs { id: &manga.id }).await?;
+    }
+    Ok(())
+}
+
 pub fn track_manga<T, F>(tracker: Option<T>, manga_title: String, chapter_number: u32, volume_number: Option<u32>, on_error: F)
 where
     T: MangaTracker,
@@ -60,6 +79,24 @@ where
             let title = SearchTerm::trimmed(&manga_title);
             if let Some(search_term) = title {
                 let response = update_reading_progress(search_term, chapter_number, volume_number, tracker).await;
+                if let Err(e) = response {
+                    on_error(e.to_string());
+                }
+            }
+        });
+    }
+}
+
+pub fn track_manga_plan_to_read<T, F>(tracker: Option<T>, manga_title: String, on_error: F)
+where
+    T: MangaTracker,
+    F: Fn(String) + Send + 'static,
+{
+    if let Some(tracker) = tracker {
+        tokio::spawn(async move {
+            let title = SearchTerm::trimmed(&manga_title);
+            if let Some(search_term) = title {
+                let response = update_plan_to_read(search_term, tracker).await;
                 if let Err(e) = response {
                     on_error(e.to_string());
                 }

--- a/src/backend/tracker/anilist.rs
+++ b/src/backend/tracker/anilist.rs
@@ -1,0 +1,368 @@
+static BASE_ANILIST_API_URL: &str = "https://graphql.anilist.co";
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use http::header::{ACCEPT, CONTENT_TYPE};
+    use http::{HeaderMap, HeaderValue, StatusCode};
+    use httpmock::Method::POST;
+    use httpmock::MockServer;
+    use manga_tui::SearchTerm;
+    use pretty_assertions::{assert_eq, assert_str_eq};
+    use reqwest::{Client, Url};
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::backend::tracker::{MangaToTrack, MangaTracker, MarkAsRead};
+
+    trait RemoveWhitespace {
+        /// Util trait for comparing two string without taking into account whitespaces and tabs (don't know a
+        /// better, smarter way xd)
+        fn remove_whitespace(&self) -> String;
+    }
+
+    impl RemoveWhitespace for serde_json::Value {
+        fn remove_whitespace(&self) -> String {
+            self.to_string().split_whitespace().map(|line| line.trim()).collect()
+        }
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct Manga {
+        id: String,
+        title: String,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct GetMangaByTitleQuery<'a> {
+        title: &'a str,
+    }
+
+    /// The body that must be sent via POST request to anilist API
+    /// Composed of the `query` which models what to request
+    /// and `variables` to indicate the data that must be sent
+    pub trait GraphqlBody: Sized {
+        fn query(&self) -> &'static str;
+        fn variables(&self) -> serde_json::Value;
+        fn into_json(self) -> serde_json::Value {
+            json!(
+                {
+                    "query" : self.query(),
+                    "variables" : self.variables()
+                }
+            )
+        }
+
+        fn into_body(self) -> String {
+            self.into_json().to_string()
+        }
+    }
+
+    impl<'a> GetMangaByTitleQuery<'a> {
+        fn new(title: &'a str) -> Self {
+            Self { title }
+        }
+    }
+
+    impl<'a> GraphqlBody for GetMangaByTitleQuery<'a> {
+        fn query(&self) -> &'static str {
+            r#"
+            query ($search: String) { 
+              Media (search: $search, type: MANGA) { 
+                id
+              }
+            }
+            "#
+        }
+
+        fn variables(&self) -> serde_json::Value {
+            json!({
+                "search" : self.title
+            })
+        }
+    }
+
+    /// set as reading,
+    /// mark chapter progress number
+    /// mark start date
+    /// mark volume progress as well
+    #[derive(Debug, Deserialize, Serialize)]
+    struct MarkMangaAsReadQuery {
+        id: u32,
+        chapter_count: u32,
+        volume_number: u32,
+    }
+
+    impl MarkMangaAsReadQuery {
+        fn new(id: u32, chapter_count: u32, volume_number: u32) -> Self {
+            Self {
+                id,
+                chapter_count,
+                volume_number,
+            }
+        }
+    }
+
+    impl GraphqlBody for MarkMangaAsReadQuery {
+        fn query(&self) -> &'static str {
+            r#"
+                mutation ($id: Int, $progress: Int, $progressVolumes : Int) {
+                  SaveMediaListEntry(mediaId: $id, progress: $progress, progressVolumes : $progressVolumes, status: CURRENT) {
+                    id
+                  }
+                }
+            "#
+        }
+
+        fn variables(&self) -> serde_json::Value {
+            json!({
+                "id" : self.id,
+                "progress" : self.chapter_count,
+                "progressVolumes" : self.volume_number
+            })
+        }
+    }
+
+    #[derive(Debug, Deserialize, Serialize, Default)]
+    struct GetMangaByTitleResponse {
+        data: GetMangaByTitleData,
+    }
+
+    #[derive(Debug, Deserialize, Serialize, Default)]
+    struct GetMangaByTitleData {
+        #[serde(rename = "Media")]
+        media: GetMangaByTitleMedia,
+    }
+
+    #[derive(Debug, Deserialize, Serialize, Default)]
+    struct GetMangaByTitleMedia {
+        id: u32,
+    }
+
+    #[derive(Debug)]
+    struct Anilist {
+        base_url: Url,
+        account_token: String,
+        client: Client,
+    }
+
+    #[derive(Debug)]
+    struct AnilistToken {
+        id: String,
+        secret: String,
+        jwt: String,
+    }
+
+    //https://anilist.co/api/v2/oauth/authorize?client_id={client_id}&redirect_uri={redirect_uri}&response_type=code"
+
+    impl Anilist {
+        pub fn new(base_url: Url) -> Self {
+            let mut default_headers = HeaderMap::new();
+
+            default_headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+            default_headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+
+            let client = Client::builder()
+                .default_headers(default_headers)
+                .timeout(Duration::from_secs(10))
+                .build()
+                .unwrap();
+
+            Self {
+                base_url,
+                client,
+                account_token: "".to_string(),
+            }
+        }
+
+        pub fn with_token(mut self, token: String) -> Self {
+            self.account_token = token;
+            self
+        }
+    }
+
+    // it should:
+    // find which manga is reading
+    // find which chapter is reading
+    // update which manga is reading
+    // update the reading progress
+    impl From<GetMangaByTitleResponse> for MangaToTrack {
+        fn from(value: GetMangaByTitleResponse) -> Self {
+            Self {
+                id: value.data.media.id.to_string(),
+            }
+        }
+    }
+
+    impl MangaTracker for Anilist {
+        async fn search_manga_by_title(&self, title: SearchTerm) -> Result<Option<MangaToTrack>, Box<dyn std::error::Error>> {
+            let query = GetMangaByTitleQuery::new(title.get());
+
+            let response = self.client.post(self.base_url.clone()).body(query.into_body()).send().await?;
+
+            if response.status() == StatusCode::NOT_FOUND {
+                return Ok(None);
+            }
+
+            let response: GetMangaByTitleResponse = response.json().await?;
+
+            Ok(Some(MangaToTrack::from(response)))
+        }
+
+        async fn mark_manga_as_read_with_chapter_count(&self, manga: MarkAsRead<'_>) -> Result<(), Box<dyn std::error::Error>> {
+            let query =
+                MarkMangaAsReadQuery::new(manga.id.parse().unwrap_or(0), manga.chapter_number, manga.volume_number.unwrap_or(0));
+
+            self.client.post(self.base_url.clone()).body(query.into_body()).send().await?;
+
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn get_manga_by_title_query_is_built_as_expected() {
+        let expected = json!({
+            "query" : r#"
+                query ($search: String) { 
+                  Media (search: $search, type: MANGA) { 
+                    id
+                  }
+                }
+            "#,
+            "variables" : {
+                "search" : "some_title"
+            }
+        });
+
+        let query = GetMangaByTitleQuery::new("some_title");
+
+        let as_json = query.into_json();
+
+        assert_str_eq!(expected.get("query").unwrap().remove_whitespace(), as_json.get("query").unwrap().remove_whitespace());
+        assert_eq!(expected.get("variables"), as_json.get("variables"));
+    }
+
+    #[tokio::test]
+    async fn anilist_searches_a_manga_by_its_title() {
+        let server = MockServer::start_async().await;
+        let anilist = Anilist::new(server.base_url().parse().unwrap());
+
+        let expected_manga = MangaToTrack {
+            id: "123123".to_string(),
+        };
+
+        let expected_server_response: GetMangaByTitleResponse = GetMangaByTitleResponse {
+            data: GetMangaByTitleData {
+                media: GetMangaByTitleMedia {
+                    id: expected_manga.id.parse().unwrap(),
+                },
+            },
+        };
+
+        let expected_body_sent = GetMangaByTitleQuery::new("some_title").into_json();
+
+        let request = server
+            .mock_async(|when, then| {
+                when.method(POST).json_body_obj(&expected_body_sent);
+
+                then.status(200).json_body_obj(&expected_server_response);
+            })
+            .await;
+
+        let response = anilist
+            .search_manga_by_title(SearchTerm::trimmed_lowercased("some_title").unwrap())
+            .await
+            .expect("should search manga by title");
+
+        request.assert_async().await;
+
+        assert_eq!(expected_manga, response.expect("should not be none"))
+    }
+
+    #[tokio::test]
+    async fn anilist_searches_a_manga_by_its_title_and_returns_none_if_not_found() {
+        let server = MockServer::start_async().await;
+        let anilist = Anilist::new(server.base_url().parse().unwrap());
+
+        let expected_body_sent = GetMangaByTitleQuery::new("some_title").into_json();
+
+        let request = server
+            .mock_async(|when, then| {
+                when.method(POST).json_body_obj(&expected_body_sent);
+                then.status(404);
+            })
+            .await;
+
+        let response = anilist
+            .search_manga_by_title(SearchTerm::trimmed_lowercased("some_title").unwrap())
+            .await
+            .expect("should search manga by title");
+
+        request.assert_async().await;
+        assert!(response.is_none())
+    }
+
+    #[test]
+    fn mark_as_read_query_is_built_as_expected() {
+        let expected = json!({
+            "query" : r#"
+                mutation ($id: Int, $progress: Int, $progressVolumes : Int) {
+                  SaveMediaListEntry(mediaId: $id, progress: $progress, progressVolumes : $progressVolumes, status: CURRENT) {
+                    id
+                  }
+                }
+            "#,
+            "variables" : {
+                 "id" : 123,
+                  "progress" : 2,
+                  "progressVolumes" : 1
+
+            }
+        });
+
+        let mark_as_read_query = MarkMangaAsReadQuery::new(123, 2, 1);
+
+        let as_json = mark_as_read_query.into_json();
+
+        assert_str_eq!(expected.get("query").unwrap().remove_whitespace(), as_json.get("query").unwrap().remove_whitespace());
+
+        assert_eq!(expected.get("variables"), as_json.get("variables"));
+    }
+
+    //#[tokio::test]
+    //async fn anilist_get_authorization_token() {
+    //    let server = MockServer::start_async().await;
+    //    let token = Uuid::new_v4().to_string();
+    //    let anilist = Anilist::new(server.base_url().parse().unwrap()).with_token(token);
+    //}
+
+    // Todo! include authorization
+    #[tokio::test]
+    async fn anilist_marks_manga_as_reading_with_chapter_and_volume_count() {
+        let server = MockServer::start_async().await;
+        let anilist = Anilist::new(server.base_url().parse().unwrap());
+
+        let expected_body_sent = MarkMangaAsReadQuery::new(100, 2, 1).into_json();
+
+        let request = server
+            .mock_async(|when, then| {
+                when.method(POST).json_body_obj(&expected_body_sent);
+                then.status(200);
+            })
+            .await;
+
+        anilist
+            .mark_manga_as_read_with_chapter_count(MarkAsRead {
+                id: "100",
+                chapter_number: 2,
+                volume_number: Some(1),
+            })
+            .await
+            .expect("should be marked as read");
+
+        request.assert_async().await;
+    }
+}

--- a/src/backend/tracker/anilist.rs
+++ b/src/backend/tracker/anilist.rs
@@ -15,6 +15,7 @@ use serde_json::json;
 
 use crate::backend::tracker::{MangaToTrack, MangaTracker, MarkAsRead};
 use crate::cli::AnilistTokenChecker;
+use crate::global::USER_AGENT;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct GetMangaByTitleQuery<'a> {
@@ -248,6 +249,7 @@ impl Anilist {
         let client = Client::builder()
             .default_headers(default_headers)
             .timeout(Duration::from_secs(10))
+            .user_agent(&*USER_AGENT)
             .build()
             .unwrap();
 

--- a/src/backend/tracker/anilist.rs
+++ b/src/backend/tracker/anilist.rs
@@ -51,7 +51,7 @@ impl<'a> GraphqlBody for GetMangaByTitleQuery<'a> {
     fn query(&self) -> &'static str {
         r#"
             query ($search: String) { 
-              Media (search: $search, type: MANGA) { 
+              Media (search: $search, type: MANGA, sort : SEARCH_MATCH) { 
                 id
               }
             }
@@ -340,7 +340,7 @@ mod tests {
         let expected = json!({
             "query" : r#"
                 query ($search: String) { 
-                  Media (search: $search, type: MANGA) { 
+                  Media (search: $search, type: MANGA, sort : SEARCH_MATCH) { 
                     id
                   }
                 }

--- a/src/backend/tracker/anilist.rs
+++ b/src/backend/tracker/anilist.rs
@@ -163,7 +163,7 @@ impl GraphqlBody for GetUserIdBody {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Anilist {
     base_url: Url,
     access_token: String,

--- a/src/backend/tracker/anilist.rs
+++ b/src/backend/tracker/anilist.rs
@@ -309,7 +309,7 @@ impl MangaTracker for Anilist {
 }
 
 impl AnilistTokenChecker for Anilist {
-    async fn verify_token(&self, token: String) -> Result<bool, Box<dyn Error>> {
+    async fn verify_token(&self, _token: String) -> Result<bool, Box<dyn Error>> {
         self.check_credentials_are_valid().await
     }
 }

--- a/src/backend/tui.rs
+++ b/src/backend/tui.rs
@@ -12,6 +12,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::task::JoinHandle;
 
 use super::fetch::ApiClient;
+use super::tracker::MangaTracker;
 use crate::common::{Artist, Author};
 use crate::view::app::{App, AppState, MangaToRead};
 use crate::view::pages::reader::{ChapterToRead, SearchChapter, SearchMangaPanel};
@@ -110,10 +111,11 @@ fn get_picker() -> Option<Picker> {
 pub async fn run_app(
     backend: impl Backend,
     api_client: impl ApiClient + SearchChapter + SearchMangaPanel,
+    manga_tracker: Option<impl MangaTracker>,
 ) -> Result<(), Box<dyn Error>> {
     let mut terminal = Terminal::new(backend)?;
 
-    let mut app = App::new(api_client, get_picker());
+    let mut app = App::new(api_client, manga_tracker, get_picker());
 
     let tick_rate = std::time::Duration::from_millis(250);
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,7 @@ use std::io::BufRead;
 use std::process::exit;
 
 use clap::{crate_version, Parser, Subcommand};
-use strum::{Display, IntoEnumIterator};
+use strum::IntoEnumIterator;
 
 use crate::backend::error_log::write_to_error_log;
 use crate::backend::filter::Languages;
@@ -21,13 +21,6 @@ fn read_input(mut input_reader: impl BufRead, logger: &impl ILogger, message: &s
     let mut input_provided = String::new();
     input_reader.read_line(&mut input_provided)?;
     Ok(input_provided)
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AnilistStatus {
-    Setup,
-    MissigCredentials,
-    InvalidAccessToken,
 }
 
 #[derive(Subcommand, Clone, Copy)]
@@ -120,8 +113,6 @@ impl CliArgs {
 
         Ok(())
     }
-
-    /// This method must check if both client_id and access_token are stored and they are not empty
 
     fn save_anilist_credentials(
         &self,
@@ -244,7 +235,6 @@ mod tests {
 
     use pretty_assertions::assert_eq;
     use uuid::Uuid;
-    use Commands::*;
 
     use super::*;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -136,7 +136,7 @@ impl CliArgs {
 
         let credentials_are_stored = storage.check_credentials_stored()?;
         if credentials_are_stored.is_none() {
-            logger.warn("The client id or the access token are empty, it is recommended you run `manga-tui anilist reset`");
+            logger.warn("The client id or the access token are empty, run `manga-tui anilist init`");
             exit(0)
         }
 
@@ -152,7 +152,7 @@ impl CliArgs {
         if access_token_is_valid {
             logger.inform("Everything is setup correctly :D");
         } else {
-            logger.error("The anilist access token is not valid, please run `manga-tui anilist reset`".into());
+            logger.error("The anilist access token is not valid, please run `manga-tui anilist init`".into());
             exit(0)
         }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -134,7 +134,7 @@ impl CliArgs {
         let storage = AnilistStorage::new();
         logger.inform("Checking client id and access token are stored");
 
-        let credentials_are_stored = storage.anilist_check_credentials_stored()?;
+        let credentials_are_stored = storage.check_credentials_stored()?;
         if credentials_are_stored.is_none() {
             logger.warn("The client id or the access token are empty, it is recommended you run `manga-tui anilist reset`");
             exit(0)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -103,8 +103,8 @@ impl CliArgs {
 
         self.save_anilist_credentials(
             AnilistCredentialsProvided {
-                access_token: &access_token,
-                client_id: &client_id,
+                access_token,
+                client_id,
             },
             storage,
         )?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,20 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::io::{self, BufRead};
+
 use clap::{crate_version, Parser, Subcommand};
 use strum::IntoEnumIterator;
 
 use crate::backend::filter::Languages;
+use crate::backend::APP_DATA_DIR;
+use crate::global::PREFERRED_LANGUAGE;
+
+fn read_input(mut input_reader: impl BufRead, message: &str) -> Result<String, Box<dyn Error>> {
+    println!("{message}");
+    let mut input_provided = String::new();
+    input_reader.read_line(&mut input_provided)?;
+    Ok(input_provided)
+}
 
 #[derive(Subcommand)]
 pub enum Commands {
@@ -10,6 +23,11 @@ pub enum Commands {
         print: bool,
         #[arg(short, long)]
         set: Option<String>,
+    },
+
+    Anilist {
+        #[arg(short, long)]
+        init: bool,
     },
 }
 
@@ -22,11 +40,183 @@ pub struct CliArgs {
     pub data_dir: bool,
 }
 
+/// Abstraction of the location where secrets will be stored
+pub trait SecretStorage {
+    fn save_secret(&mut self, secret_name: String, value: String) -> Result<(), Box<dyn Error>>;
+    fn save_multiple_secrets(&mut self, values: HashMap<String, String>) -> Result<(), Box<dyn Error>>;
+    fn get_secret(&self, _secret_name: &str) -> Result<String, Box<dyn Error>> {
+        Err("not implemented".into())
+    }
+}
+
+struct AnilistCredentialsProvided<'a> {
+    pub code: &'a str,
+    pub secret: &'a str,
+    pub client_id: &'a str,
+}
+
 impl CliArgs {
+    pub fn new() -> Self {
+        Self {
+            command: None,
+            data_dir: false,
+        }
+    }
+
+    pub fn with_command(mut self, command: Commands) -> Self {
+        self.command = Some(command);
+        self
+    }
+
     pub fn print_available_languages() {
         println!("The available languages are:");
         Languages::iter().filter(|lang| *lang != Languages::Unkown).for_each(|lang| {
             println!("{} {} | iso code : {}", lang.as_emoji(), lang.as_human_readable().to_lowercase(), lang.as_iso_code())
         });
+    }
+
+    fn save_anilist_credentials(
+        &self,
+        credentials: AnilistCredentialsProvided<'_>,
+        storage: &mut dyn SecretStorage,
+    ) -> Result<(), Box<dyn Error>> {
+        storage.save_multiple_secrets(HashMap::from([
+            ("anilist_client_id".to_string(), credentials.client_id.to_string()),
+            ("anilist_code".to_string(), credentials.code.to_string()),
+            ("anilist_secret".to_string(), credentials.secret.to_string()),
+        ]))?;
+
+        Ok(())
+    }
+
+    pub fn init_anilist(self, mut input_reader: impl BufRead, storage: &mut dyn SecretStorage) -> Result<(), Box<dyn Error>> {
+        let client_id = read_input(&mut input_reader, "Provide the client id")?;
+        let secret = read_input(&mut input_reader, "Provide the secret")?;
+        let code = read_input(&mut input_reader, "Provide the code")?;
+
+        self.save_anilist_credentials(
+            AnilistCredentialsProvided {
+                code: &code,
+                secret: &secret,
+                client_id: &client_id,
+            },
+            storage,
+        )?;
+
+        println!("Anilist was correctly setup :D");
+
+        Ok(())
+    }
+
+    pub fn proccess_args(self) -> Result<(), Box<dyn Error>> {
+        if self.data_dir {
+            let app_dir = APP_DATA_DIR.as_ref().unwrap();
+            println!("{}", app_dir.to_str().unwrap());
+            return Ok(());
+        }
+
+        match self.command {
+            Some(command) => match command {
+                Commands::Lang { print, set } => {
+                    if print {
+                        Self::print_available_languages();
+                        return Ok(());
+                    }
+
+                    match set {
+                        Some(lang) => {
+                            let try_lang = Languages::try_from_iso_code(lang.as_str());
+
+                            if try_lang.is_none() {
+                                println!(
+                                    "`{}` is not a valid ISO language code, run `{} lang --print` to list available languages and their ISO codes",
+                                    lang,
+                                    env!("CARGO_BIN_NAME")
+                                );
+
+                                return Ok(());
+                            }
+
+                            PREFERRED_LANGUAGE.set(try_lang.unwrap()).unwrap();
+                        },
+                        None => {
+                            PREFERRED_LANGUAGE.set(Languages::default()).unwrap();
+                        },
+                    }
+                    Ok(())
+                },
+
+                Commands::Anilist { init } => todo!(),
+            },
+            None => {
+                PREFERRED_LANGUAGE.set(Languages::default()).unwrap();
+                Ok(())
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::error::Error;
+    use std::io::{BufReader, Cursor};
+
+    use pretty_assertions::assert_eq;
+    use uuid::Uuid;
+    use Commands::*;
+
+    use super::*;
+
+    #[derive(Default, Clone)]
+    struct MockStorage {
+        secrets_stored: HashMap<String, String>,
+    }
+
+    impl SecretStorage for MockStorage {
+        fn save_secret(&mut self, name: String, value: String) -> Result<(), Box<dyn Error>> {
+            self.secrets_stored.insert(name, value);
+            Ok(())
+        }
+
+        fn save_multiple_secrets(&mut self, values: HashMap<String, String>) -> Result<(), Box<dyn Error>> {
+            for (key, name) in values {
+                self.save_secret(key, name)?;
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn it_saves_anilist_account_credentials() {
+        let cli = CliArgs::new();
+        let client_id_provided = Uuid::new_v4().to_string();
+        let secret_provided = Uuid::new_v4().to_string();
+        let code_provided = Uuid::new_v4().to_string();
+
+        let mut storage = MockStorage::default();
+
+        cli.save_anilist_credentials(
+            AnilistCredentialsProvided {
+                code: &code_provided,
+                secret: &secret_provided,
+                client_id: &client_id_provided,
+            },
+            &mut storage,
+        )
+        .expect("should not panic");
+
+        let (name, id) = storage.secrets_stored.get_key_value("anilist_client_id").unwrap();
+        let (key_name2, secret) = storage.secrets_stored.get_key_value("anilist_secret").unwrap();
+        let (key_name3, code) = storage.secrets_stored.get_key_value("anilist_code").unwrap();
+
+        assert_eq!("anilist_client_id", name);
+        assert_eq!(client_id_provided, *id);
+
+        assert_eq!("anilist_secret", key_name2);
+        assert_eq!(secret_provided, *secret);
+
+        assert_eq!("anilist_code", key_name3);
+        assert_eq!(code_provided, *code);
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,10 +1,14 @@
 use std::collections::HashMap;
+use std::error::Error;
+use std::fmt::Display;
 
+use manga_tui::SearchTerm;
 use ratatui::layout::Rect;
 use ratatui_image::protocol::Protocol;
 use strum::{Display, EnumIter};
 
 use crate::backend::filter::Languages;
+use crate::backend::tracker::{MangaTracker, MarkAsRead};
 
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct Author {
@@ -88,4 +92,15 @@ impl ImageState {
     pub fn is_empty(&self) -> bool {
         self.image_state.is_empty()
     }
+}
+
+pub fn format_error_message_tracking_reading_history<A: Display, B: Display, C: Display>(
+    chapter: A,
+    manga_title: B,
+    error: C,
+) -> String {
+    format!(
+        "Could not track reading progress of chapter : {} \n of manga : {}, more details about the error : \n ERROR | {}",
+        chapter, manga_title, error
+    )
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,15 +1,11 @@
 use std::collections::HashMap;
-use std::error::Error;
 use std::fmt::Display;
 
-use manga_tui::SearchTerm;
 use ratatui::layout::Rect;
 use ratatui_image::protocol::Protocol;
 use strum::{Display, EnumIter};
 
 use crate::backend::filter::Languages;
-use crate::backend::tracker::{MangaTracker, MarkAsRead};
-
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct Author {
     pub id: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,7 @@ pub struct MangaTuiConfig {
     pub image_quality: ImageQuality,
     pub auto_bookmark: bool,
     pub amount_pages: u8,
+    pub track_reading_when_download: bool,
 }
 
 impl Default for MangaTuiConfig {
@@ -53,6 +54,7 @@ impl Default for MangaTuiConfig {
             auto_bookmark: true,
             download_type: DownloadType::default(),
             image_quality: ImageQuality::default(),
+            track_reading_when_download: false,
         }
     }
 }
@@ -122,6 +124,18 @@ auto_bookmark = true
             )?;
         }
 
+        if !existing_config.contains_key("track_reading_when_download") {
+            file.write_all(
+                "
+# Whether or not downloading a manga counts as reading it on services like anilist
+# values : true, false
+# default : false
+track_reading_when_download = false
+"
+                .as_bytes(),
+            )?;
+        }
+
         let mut contents = String::new();
 
         file.read_to_string(&mut contents)?;
@@ -183,6 +197,11 @@ mod tests {
     # values : 0-255
     #default : 5
     amount_pages = 5
+
+# Whether or not downloading a manga counts as reading it on services like anilist
+# values : true, false
+# default : false
+track_reading_when_download = false
                 "#;
 
         MangaTuiConfig::add_missing_fields(&mut test_file, current_contents.parse::<Table>().unwrap()).unwrap();
@@ -207,6 +226,11 @@ auto_bookmark = true
 # values : 0-255
 #default : 5
 amount_pages = 5
+
+# Whether or not downloading a manga counts as reading it on services like anilist
+# values : true, false
+# default : false
+track_reading_when_download = false
             "#;
 
         let mut test_file = Cursor::new(Vec::new());
@@ -223,6 +247,11 @@ auto_bookmark = true
 # values : 0-255
 #default : 5
 amount_pages = 5
+
+# Whether or not downloading a manga counts as reading it on services like anilist
+# values : true, false
+# default : false
+track_reading_when_download = false
             "#;
 
         MangaTuiConfig::add_missing_fields(&mut test_file, current_contents.parse::<Table>().unwrap()).unwrap();

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use once_cell::sync::{Lazy, OnceCell};
 use ratatui::style::{Style, Stylize};
 
@@ -10,6 +12,16 @@ pub static INSTRUCTIONS_STYLE: Lazy<Style> = Lazy::new(|| Style::default().bold(
 pub static ERROR_STYLE: Lazy<Style> = Lazy::new(|| Style::default().bold().underlined().red().on_black());
 
 pub static CURRENT_LIST_ITEM_STYLE: Lazy<Style> = Lazy::new(|| Style::default().on_blue());
+
+pub static USER_AGENT: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "manga-tui/{} ({}/{}/{})",
+        env!("CARGO_PKG_VERSION"),
+        std::env::consts::FAMILY,
+        std::env::consts::OS,
+        std::env::consts::ARCH
+    )
+});
 
 #[cfg(test)]
 pub mod test_utils {

--- a/src/global.rs
+++ b/src/global.rs
@@ -10,3 +10,65 @@ pub static INSTRUCTIONS_STYLE: Lazy<Style> = Lazy::new(|| Style::default().bold(
 pub static ERROR_STYLE: Lazy<Style> = Lazy::new(|| Style::default().bold().underlined().red().on_black());
 
 pub static CURRENT_LIST_ITEM_STYLE: Lazy<Style> = Lazy::new(|| Style::default().on_blue());
+
+#[cfg(test)]
+pub mod test_utils {
+    use std::error::Error;
+
+    use crate::backend::tracker::MangaTracker;
+
+    #[derive(Debug, Clone)]
+    pub struct TrackerTest {
+        pub should_fail: bool,
+        pub title_manga_tracked: Option<String>,
+        pub error_message: Option<String>,
+    }
+
+    impl TrackerTest {
+        pub fn new() -> Self {
+            Self {
+                title_manga_tracked: None,
+                should_fail: false,
+                error_message: None,
+            }
+        }
+
+        pub fn failing() -> Self {
+            Self {
+                should_fail: true,
+                title_manga_tracked: None,
+                error_message: None,
+            }
+        }
+
+        pub fn failing_with_error_message(error_message: &str) -> Self {
+            Self {
+                should_fail: true,
+                title_manga_tracked: None,
+                error_message: Some(error_message.to_string()),
+            }
+        }
+    }
+
+    impl MangaTracker for TrackerTest {
+        async fn search_manga_by_title(
+            &self,
+            _title: manga_tui::SearchTerm,
+        ) -> Result<Option<crate::backend::tracker::MangaToTrack>, Box<dyn std::error::Error>> {
+            if self.should_fail {
+                return Err(self.error_message.clone().unwrap_or("".to_string()).into());
+            }
+            Ok(None)
+        }
+
+        async fn mark_manga_as_read_with_chapter_count(
+            &self,
+            _manga: crate::backend::tracker::MarkAsRead<'_>,
+        ) -> Result<(), Box<dyn Error>> {
+            if self.should_fail {
+                return Err(self.error_message.clone().unwrap_or("".to_string()).into());
+            }
+            Ok(())
+        }
+    }
+}

--- a/src/global.rs
+++ b/src/global.rs
@@ -15,7 +15,7 @@ pub static CURRENT_LIST_ITEM_STYLE: Lazy<Style> = Lazy::new(|| Style::default().
 pub mod test_utils {
     use std::error::Error;
 
-    use crate::backend::tracker::MangaTracker;
+    use crate::backend::tracker::{MangaTracker, PlanToReadArgs};
 
     #[derive(Debug, Clone)]
     pub struct TrackerTest {
@@ -65,6 +65,13 @@ pub mod test_utils {
             &self,
             _manga: crate::backend::tracker::MarkAsRead<'_>,
         ) -> Result<(), Box<dyn Error>> {
+            if self.should_fail {
+                return Err(self.error_message.clone().unwrap_or("".to_string()).into());
+            }
+            Ok(())
+        }
+
+        async fn mark_manga_as_plan_to_read(&self, _manga_to_plan_to_read: PlanToReadArgs<'_>) -> Result<(), Box<dyn Error>> {
             if self.should_fail {
                 return Err(self.error_message.clone().unwrap_or("".to_string()).into());
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,11 @@ impl SearchTerm {
         if search_term.is_empty() { None } else { Some(Self(search_term.to_lowercase())) }
     }
 
+    pub fn trimmed(search_term: &str) -> Option<Self> {
+        let search_term = search_term.trim();
+        if search_term.is_empty() { None } else { Some(Self(search_term.to_string())) }
+    }
+
     pub fn get(&self) -> &str {
         &self.0
     }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,1 +1,38 @@
+use std::error::Error;
 
+use log::{error, info, warn};
+
+/// Abstraction for printing to the console messages
+pub trait ILogger {
+    fn inform(&self, message: impl AsRef<str>) {
+        println!("{}", message.as_ref());
+    }
+
+    fn error(&self, error: Box<dyn Error>) {
+        println!("ERROR | {}", error)
+    }
+
+    fn warn(&self, warning: impl AsRef<str>) {
+        println!("WARN | {}", warning.as_ref())
+    }
+}
+
+pub struct DefaultLogger;
+
+pub struct Logger;
+
+impl ILogger for DefaultLogger {}
+
+impl ILogger for Logger {
+    fn inform(&self, message: impl AsRef<str>) {
+        info!("{}", message.as_ref());
+    }
+
+    fn warn(&self, warning: impl AsRef<str>) {
+        warn!("{}", warning.as_ref());
+    }
+
+    fn error(&self, error: Box<dyn Error>) {
+        error!("{error}");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 
 use std::time::Duration;
 
+use backend::release_notifier::{ReleaseNotifier, GITHUB_URL};
 use backend::secrets::anilist::AnilistStorage;
 use backend::tracker::anilist::{Anilist, BASE_ANILIST_API_URL};
 use clap::Parser;
@@ -40,6 +41,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli_args = CliArgs::parse();
 
     cli_args.proccess_args().await?;
+
+    let notifier = ReleaseNotifier::new(GITHUB_URL.parse().unwrap());
+
+    if let Err(e) = notifier.check_new_releases(&logger).await {
+        logger.error(e.into());
+    }
 
     match build_data_dir() {
         Ok(_) => {},

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 #![allow(dead_code)]
 #![allow(deprecated)]
 
-use backend::fetch::ApiClient;
 use clap::Parser;
+use http::StatusCode;
+use log::LevelFilter;
 use ratatui::backend::CrosstermBackend;
-use reqwest::StatusCode;
 
 use self::backend::build_data_dir;
 use self::backend::database::Database;
@@ -26,10 +26,14 @@ mod view;
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 7)]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    simple_logger::init()?;
+    pretty_env_logger::formatted_builder()
+        .format_module_path(false)
+        .filter_level(LevelFilter::Info)
+        .init();
+
     let cli_args = CliArgs::parse();
 
-    cli_args.proccess_args()?;
+    cli_args.proccess_args().await?;
 
     match build_data_dir() {
         Ok(_) => {},
@@ -78,5 +82,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     init()?;
     run_app(CrosstermBackend::new(std::io::stdout()), MangadexClient::global().clone()).await?;
     restore()?;
+
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,17 @@
 #![allow(dead_code)]
 #![allow(deprecated)]
 
+use backend::fetch::ApiClient;
 use clap::Parser;
 use ratatui::backend::CrosstermBackend;
 use reqwest::StatusCode;
 
+use self::backend::build_data_dir;
 use self::backend::database::Database;
 use self::backend::error_log::init_error_hooks;
 use self::backend::fetch::{MangadexClient, API_URL_BASE, COVER_IMG_URL_BASE, MANGADEX_CLIENT_INSTANCE};
 use self::backend::migration::migrate_version;
 use self::backend::tui::{init, restore, run_app};
-use self::backend::{build_data_dir, APP_DATA_DIR};
 use self::cli::CliArgs;
 use self::config::MangaTuiConfig;
 
@@ -25,6 +26,7 @@ mod view;
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 7)]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    simple_logger::init()?;
     let cli_args = CliArgs::parse();
 
     cli_args.proccess_args()?;

--- a/src/view/app.rs
+++ b/src/view/app.rs
@@ -47,7 +47,7 @@ where
     pub current_tab: SelectedPage,
     pub manga_page: Option<MangaPage<S>>,
     pub manga_reader_page: Option<MangaReader<T, S>>,
-    pub search_page: SearchPage,
+    pub search_page: SearchPage<T, S>,
     pub home_page: Home,
     pub feed_page: Feed<T>,
     api_client: T,
@@ -131,7 +131,8 @@ impl<T: ApiClient + SearchChapter + SearchMangaPanel, S: MangaTracker> App<T, S>
         App {
             picker,
             current_tab: SelectedPage::default(),
-            search_page: SearchPage::new(picker).with_global_sender(global_event_tx.clone()),
+            search_page: SearchPage::new(picker, api_client.clone(), manga_tracker.clone())
+                .with_global_sender(global_event_tx.clone()),
             feed_page: Feed::new()
                 .with_global_sender(global_event_tx.clone())
                 .with_api_client(api_client.clone()),

--- a/src/view/pages/manga.rs
+++ b/src/view/pages/manga.rs
@@ -1,7 +1,6 @@
 use std::error::Error;
 use std::future::Future;
 use std::io::Cursor;
-use std::u32;
 
 use crossterm::event::{KeyCode, KeyEvent, MouseEvent, MouseEventKind};
 use image::io::Reader;
@@ -867,7 +866,7 @@ impl<T: MangaTracker> MangaPage<T> {
                                 // This conversion is needed so that we take into account chapters
                                 // like 1.2, 10.1 etc
                                 number.parse::<f64>().unwrap_or(0.0) as u32,
-                                volume_number.map(|vol| vol.parse().ok()).flatten(),
+                                volume_number.and_then(|vol| vol.parse().ok()),
                                 move |error| {
                                     write_to_error_log(
                                         format_error_message_tracking_reading_history(
@@ -1214,7 +1213,7 @@ impl<T: MangaTracker> MangaPage<T> {
                 },
                 MangaPageEvents::ReadSuccesful(chapter_to_read, manga_to_read) => {
                     self.state = PageState::DisplayingChapters;
-                    let volume = chapter_to_read.clone().volume_number.map(|vol| vol.parse::<u32>().ok()).flatten();
+                    let volume = chapter_to_read.clone().volume_number.and_then(|vol| vol.parse::<u32>().ok());
                     self.track_manga(self.manga_tracker.clone(), self.manga.title.clone(), chapter_to_read.number as u32, volume);
 
                     self.local_event_tx.send(MangaPageEvents::CheckChapterStatus).ok();

--- a/src/view/pages/reader.rs
+++ b/src/view/pages/reader.rs
@@ -899,7 +899,6 @@ mod test {
     use self::mpsc::unbounded_channel;
     use super::*;
     use crate::backend::database::{ChapterToBookmark, Database};
-    use crate::common::format_error_message_tracking_reading_history;
     use crate::global::test_utils::TrackerTest;
     use crate::view::widgets::press_key;
 

--- a/src/view/pages/reader.rs
+++ b/src/view/pages/reader.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 use std::error::Error;
+use std::fmt::Display;
 use std::future::Future;
 
 use crossterm::event::{KeyCode, KeyEvent};
@@ -25,7 +26,9 @@ use crate::backend::database::{
 };
 use crate::backend::error_log::{write_to_error_log, ErrorType};
 use crate::backend::filter::Languages;
+use crate::backend::tracker::{track_manga, MangaTracker};
 use crate::backend::tui::Events;
+use crate::common::format_error_message_tracking_reading_history;
 use crate::config::MangaTuiConfig;
 use crate::global::{ERROR_STYLE, INSTRUCTIONS_STYLE};
 use crate::view::tasks::reader::get_manga_panel;
@@ -91,6 +94,7 @@ pub enum MangaReaderEvents {
     FetchPages,
     LoadPage(PageData),
     FailedPage(usize),
+    ErrorTrackingReadingProgress(String),
 }
 
 pub struct Page {
@@ -117,6 +121,28 @@ pub struct ChapterToRead {
     pub num_page_bookmarked: Option<u32>,
     pub language: Languages,
     pub pages_url: Vec<Url>,
+}
+
+impl Display for ChapterToRead {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            r#"
+     id: {},
+     title: {},
+     number: {},
+     volume: {}
+     Page bookmarked: {}
+     language: {},
+        "#,
+            self.id,
+            self.title,
+            self.number,
+            self.volume_number.clone().unwrap_or("none".to_string()),
+            self.num_page_bookmarked.unwrap_or(0),
+            self.language,
+        )
+    }
 }
 
 impl Default for ChapterToRead {
@@ -295,7 +321,11 @@ impl ListOfChapters {
     }
 }
 
-pub struct MangaReader<T: SearchChapter + SearchMangaPanel> {
+pub struct MangaReader<T, S>
+where
+    T: SearchChapter + SearchMangaPanel,
+    S: MangaTracker,
+{
     manga_title: String,
     manga_id: String,
     pub list_of_chapters: ListOfChapters,
@@ -309,6 +339,7 @@ pub struct MangaReader<T: SearchChapter + SearchMangaPanel> {
     picker: Picker,
     search_next_chapter_loader: ThrobberState,
     api_client: T,
+    pub manga_tracker: Option<S>,
     pub auto_bookmark: bool,
     pub global_event_tx: Option<UnboundedSender<Events>>,
     pub local_action_tx: UnboundedSender<MangaReaderActions>,
@@ -317,7 +348,11 @@ pub struct MangaReader<T: SearchChapter + SearchMangaPanel> {
     pub local_event_rx: UnboundedReceiver<MangaReaderEvents>,
 }
 
-impl<T: SearchChapter + SearchMangaPanel> Component for MangaReader<T> {
+impl<T, S> Component for MangaReader<T, S>
+where
+    T: SearchChapter + SearchMangaPanel,
+    S: MangaTracker,
+{
     type Actions = MangaReaderActions;
 
     fn render(&mut self, area: Rect, frame: &mut Frame<'_>) {
@@ -398,7 +433,11 @@ impl<T: SearchChapter + SearchMangaPanel> Component for MangaReader<T> {
     }
 }
 
-impl<T: SearchChapter + SearchMangaPanel> MangaReader<T> {
+impl<T, S> MangaReader<T, S>
+where
+    T: SearchChapter + SearchMangaPanel,
+    S: MangaTracker,
+{
     pub fn new(chapter: ChapterToRead, manga_id: String, picker: Picker, api_client: T) -> Self {
         let set: JoinSet<()> = JoinSet::new();
         let (local_action_tx, local_action_rx) = mpsc::unbounded_channel::<MangaReaderActions>();
@@ -421,6 +460,7 @@ impl<T: SearchChapter + SearchMangaPanel> MangaReader<T> {
             local_event_tx,
             local_event_rx,
             state: State::default(),
+            manga_tracker: None,
             current_page_size: PageSize::default(),
             pages_list: PagesList::default(),
             search_next_chapter_loader: ThrobberState::default(),
@@ -445,6 +485,11 @@ impl<T: SearchChapter + SearchMangaPanel> MangaReader<T> {
 
     pub fn with_manga_title(mut self, title: String) -> Self {
         self.manga_title = title;
+        self
+    }
+
+    pub fn with_manga_tracker(mut self, manga_tracker: Option<S>) -> Self {
+        self.manga_tracker = manga_tracker;
         self
     }
 
@@ -505,6 +550,7 @@ impl<T: SearchChapter + SearchMangaPanel> MangaReader<T> {
 
         self.init_fetching_pages();
         self.init_save_reading_history();
+        self.track_manga_reading_history(self.manga_tracker.clone());
     }
 
     fn init_save_reading_history(&self) {
@@ -615,6 +661,21 @@ impl<T: SearchChapter + SearchMangaPanel> MangaReader<T> {
         }
     }
 
+    fn track_manga_reading_history(&self, manga_tracker: Option<S>) {
+        let chapter_to_track = self.current_chapter.clone();
+        let tx = self.local_event_tx.clone();
+
+        track_manga(
+            manga_tracker,
+            self.manga_title.clone(),
+            chapter_to_track.number as u32,
+            chapter_to_track.volume_number.clone().unwrap_or("0".to_string()).parse().ok(),
+            move |error| {
+                tx.send(MangaReaderEvents::ErrorTrackingReadingProgress(error)).ok();
+            },
+        );
+    }
+
     pub fn exit(&mut self) {
         if self.auto_bookmark {
             self.bookmark_current_chapter()
@@ -705,8 +766,16 @@ impl<T: SearchChapter + SearchMangaPanel> MangaReader<T> {
                 MangaReaderEvents::FetchPages => self.fetch_pages(),
                 MangaReaderEvents::LoadPage(maybe_data) => self.load_page(maybe_data),
                 MangaReaderEvents::FailedPage(index) => self.failed_page(index),
+                MangaReaderEvents::ErrorTrackingReadingProgress(error_message) => self.log_manga_tracking_error(error_message),
             }
         }
+    }
+
+    fn log_manga_tracking_error(&self, error_message: String) {
+        write_to_error_log(
+            format_error_message_tracking_reading_history(self.current_chapter.clone(), self.manga_title.clone(), error_message)
+                .into(),
+        );
     }
 
     fn handle_key_events(&mut self, key_event: KeyEvent) {
@@ -830,6 +899,8 @@ mod test {
     use self::mpsc::unbounded_channel;
     use super::*;
     use crate::backend::database::{ChapterToBookmark, Database};
+    use crate::common::format_error_message_tracking_reading_history;
+    use crate::global::test_utils::TrackerTest;
     use crate::view::widgets::press_key;
 
     #[derive(Clone)]
@@ -885,7 +956,11 @@ mod test {
         }
     }
 
-    fn initialize_reader_page<T: SearchChapter + SearchMangaPanel>(api_client: T) -> MangaReader<T> {
+    fn initialize_reader_page<T, S>(api_client: T) -> MangaReader<T, S>
+    where
+        T: SearchChapter + SearchMangaPanel,
+        S: MangaTracker,
+    {
         let picker = Picker::new((8, 19));
         let chapter_id = "some_id".to_string();
         let url_imgs = vec!["http://localhost".parse().unwrap(), "http://localhost".parse().unwrap()];
@@ -1192,7 +1267,7 @@ mod test {
 
     #[tokio::test]
     async fn trigget_key_events() {
-        let mut reader_page = initialize_reader_page(TestApiClient::new());
+        let mut reader_page: MangaReader<TestApiClient, TrackerTest> = initialize_reader_page(TestApiClient::new());
 
         press_key(&mut reader_page, KeyCode::Char('j'));
         let action = reader_page.local_action_rx.recv().await.unwrap();
@@ -1207,7 +1282,7 @@ mod test {
 
     #[tokio::test]
     async fn handle_key_events() {
-        let mut reader_page = initialize_reader_page(TestApiClient::new());
+        let mut reader_page: MangaReader<TestApiClient, TrackerTest> = initialize_reader_page(TestApiClient::new());
 
         reader_page.pages_list = PagesList::new(vec![PagesItem::new(0), PagesItem::new(1), PagesItem::new(2)]);
 
@@ -1239,7 +1314,8 @@ mod test {
             ..Default::default()
         };
 
-        let mut manga_reader = MangaReader::new(chapter, "some_id".to_string(), Picker::new((8, 8)), TestApiClient::new());
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
+            MangaReader::new(chapter, "some_id".to_string(), Picker::new((8, 8)), TestApiClient::new());
 
         manga_reader.init_fetching_pages();
         manga_reader.fetch_pages();
@@ -1252,7 +1328,7 @@ mod test {
 
     #[test]
     fn it_increases_page_size_based_on_manga_panel_dimesions() {
-        let mut manga_reader =
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
             MangaReader::new(ChapterToRead::default(), "some_id".to_string(), Picker::new((8, 8)), TestApiClient::new());
 
         manga_reader.resize_based_on_image_size(500, 200);
@@ -1272,7 +1348,7 @@ mod test {
     #[test]
     fn it_does_not_initiate_search_next_chapter_if_there_is_no_next_chapter() {
         let list_of_chapters = ListOfChapters::default();
-        let mut manga_reader =
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
             MangaReader::new(ChapterToRead::default(), "".to_string(), Picker::new((8, 8)), TestApiClient::new())
                 .with_list_of_chapters(list_of_chapters);
 
@@ -1284,7 +1360,7 @@ mod test {
     #[test]
     fn it_does_not_initiate_search_previous_chapter_if_there_is_no_previous_chapter() {
         let list_of_chapters = ListOfChapters::default();
-        let mut manga_reader =
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
             MangaReader::new(ChapterToRead::default(), "".to_string(), Picker::new((8, 8)), TestApiClient::new())
                 .with_list_of_chapters(list_of_chapters);
 
@@ -1318,8 +1394,9 @@ mod test {
             ..Default::default()
         };
 
-        let mut manga_reader = MangaReader::new(current_chapter, "".to_string(), Picker::new((8, 8)), TestApiClient::new())
-            .with_list_of_chapters(list_of_chapters);
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
+            MangaReader::new(current_chapter, "".to_string(), Picker::new((8, 8)), TestApiClient::new())
+                .with_list_of_chapters(list_of_chapters);
 
         manga_reader.initiate_search_next_chapter();
 
@@ -1358,8 +1435,9 @@ mod test {
             ..Default::default()
         };
 
-        let mut manga_reader = MangaReader::new(current_chapter, "".to_string(), Picker::new((8, 8)), TestApiClient::new())
-            .with_list_of_chapters(list_of_chapters);
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
+            MangaReader::new(current_chapter, "".to_string(), Picker::new((8, 8)), TestApiClient::new())
+                .with_list_of_chapters(list_of_chapters);
 
         manga_reader.initiate_search_previous_chapter();
 
@@ -1374,7 +1452,7 @@ mod test {
 
     #[tokio::test]
     async fn it_sends_search_next_chapter_action_on_w_key_press() {
-        let mut manga_reader =
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
             MangaReader::new(ChapterToRead::default(), "".to_string(), Picker::new((8, 8)), TestApiClient::new());
 
         press_key(&mut manga_reader, KeyCode::Char('w'));
@@ -1389,7 +1467,7 @@ mod test {
 
     #[tokio::test]
     async fn it_sends_search_previous_chapter_event_on_b_key_press() {
-        let mut manga_reader =
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
             MangaReader::new(ChapterToRead::default(), "".to_string(), Picker::new((8, 8)), TestApiClient::new());
 
         press_key(&mut manga_reader, KeyCode::Char('b'));
@@ -1416,7 +1494,8 @@ mod test {
 
         let api_client = TestApiClient::with_response(expected.clone());
 
-        let mut manga_reader = MangaReader::new(ChapterToRead::default(), "some_id".to_string(), Picker::new((8, 8)), api_client);
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
+            MangaReader::new(ChapterToRead::default(), "some_id".to_string(), Picker::new((8, 8)), api_client);
 
         manga_reader.search_chapter("some_id".to_string());
 
@@ -1432,7 +1511,8 @@ mod test {
     async fn it_searches_chapter_and_sends_error_event() {
         let api_client = TestApiClient::with_failing_request();
 
-        let mut manga_reader = MangaReader::new(ChapterToRead::default(), "some_id".to_string(), Picker::new((8, 8)), api_client);
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
+            MangaReader::new(ChapterToRead::default(), "some_id".to_string(), Picker::new((8, 8)), api_client);
 
         manga_reader.search_chapter("some_id".to_string());
 
@@ -1458,7 +1538,8 @@ mod test {
 
         let api_client = TestApiClient::with_response(expected.clone());
 
-        let mut manga_reader = MangaReader::new(ChapterToRead::default(), "some_id".to_string(), Picker::new((8, 8)), api_client);
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
+            MangaReader::new(ChapterToRead::default(), "some_id".to_string(), Picker::new((8, 8)), api_client);
 
         manga_reader.state = State::SearchingChapter;
 
@@ -1472,7 +1553,8 @@ mod test {
     fn it_resets_pages_after_chapter_was_found() {
         let api_client = TestApiClient::new();
 
-        let mut manga_reader = MangaReader::new(ChapterToRead::default(), "some_id".to_string(), Picker::new((8, 8)), api_client);
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
+            MangaReader::new(ChapterToRead::default(), "some_id".to_string(), Picker::new((8, 8)), api_client);
 
         manga_reader.pages = vec![Page::new(), Page::new()];
         manga_reader.pages_list.pages = vec![PagesItem::new(1), PagesItem::new(1)];
@@ -1488,7 +1570,8 @@ mod test {
     #[tokio::test]
     async fn it_send_event_to_search_pages_after_chapter_was_loaded() {
         let api_client = TestApiClient::new();
-        let mut manga_reader = MangaReader::new(ChapterToRead::default(), "".to_string(), Picker::new((8, 8)), api_client);
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
+            MangaReader::new(ChapterToRead::default(), "".to_string(), Picker::new((8, 8)), api_client);
 
         manga_reader.load_chapter(ChapterToRead::default());
 
@@ -1506,7 +1589,8 @@ mod test {
     async fn it_send_event_to_save_reading_status_to_database_after_chapter_was_loaded() {
         let api_client = TestApiClient::new();
 
-        let mut manga_reader = MangaReader::new(ChapterToRead::default(), "".to_string(), Picker::new((8, 8)), api_client);
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
+            MangaReader::new(ChapterToRead::default(), "".to_string(), Picker::new((8, 8)), api_client);
 
         let new_chapter: ChapterToRead = ChapterToRead {
             id: "chapter_to_save".to_string(),
@@ -1537,7 +1621,8 @@ mod test {
             ..Default::default()
         };
 
-        let manga_reader = MangaReader::new(chapter, "".to_string(), Picker::new((8, 8)), TestApiClient::new());
+        let manga_reader: MangaReader<TestApiClient, TrackerTest> =
+            MangaReader::new(chapter, "".to_string(), Picker::new((8, 8)), TestApiClient::new());
 
         let id_chapter_saved = manga_reader.save_reading_history(&mut conn)?;
 
@@ -1558,7 +1643,8 @@ mod test {
 
         let api_client = TestApiClient::new();
 
-        let mut manga_reader = MangaReader::new(ChapterToRead::default(), "some_id".to_string(), Picker::new((8, 8)), api_client);
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
+            MangaReader::new(ChapterToRead::default(), "some_id".to_string(), Picker::new((8, 8)), api_client);
 
         manga_reader
             .local_event_tx
@@ -1574,7 +1660,8 @@ mod test {
     fn it_is_set_as_error_searching_chapter_on_event() {
         let api_client = TestApiClient::new();
 
-        let mut manga_reader = MangaReader::new(ChapterToRead::default(), "some_id".to_string(), Picker::new((8, 8)), api_client);
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
+            MangaReader::new(ChapterToRead::default(), "some_id".to_string(), Picker::new((8, 8)), api_client);
 
         manga_reader.local_event_tx.send(MangaReaderEvents::ErrorSearchingChapter).ok();
 
@@ -1614,7 +1701,7 @@ mod test {
 
     #[test]
     fn it_sets_current_chapter_as_bookmarked_and_sets_state_as_bookmarked() {
-        let mut manga_reader =
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
             MangaReader::new(ChapterToRead::default(), "".to_string(), Picker::new((8, 8)), TestApiClient::new());
 
         let mut database = TestDatabase::new();
@@ -1633,7 +1720,8 @@ mod test {
             ..Default::default()
         };
 
-        let mut manga_reader = MangaReader::new(chapter_to_read, "".to_string(), Picker::new((8, 8)), TestApiClient::new());
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
+            MangaReader::new(chapter_to_read, "".to_string(), Picker::new((8, 8)), TestApiClient::new());
 
         manga_reader.pages_list = PagesList::new(vec![PagesItem::new(0), PagesItem::new(1)]);
 
@@ -1647,7 +1735,7 @@ mod test {
 
     #[tokio::test]
     async fn it_does_not_send_event_to_bookmark_chapter_on_m_key_press_if_autobookmarking_is_true() {
-        let mut manga_reader =
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
             MangaReader::new(ChapterToRead::default(), "".to_string(), Picker::new((8, 8)), TestApiClient::new());
 
         manga_reader.set_auto_bookmark();
@@ -1660,7 +1748,7 @@ mod test {
     #[tokio::test]
     async fn it_sends_event_go_manga_page_on_exit() {
         let (tx, mut rx) = unbounded_channel::<Events>();
-        let mut manga_reader =
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
             MangaReader::new(ChapterToRead::default(), "".to_string(), Picker::new((8, 8)), TestApiClient::new())
                 .with_global_sender(tx);
 
@@ -1671,5 +1759,36 @@ mod test {
         let result = timeout(Duration::from_millis(250), rx.recv()).await.unwrap().unwrap();
 
         assert_eq!(expected, result)
+    }
+
+    #[tokio::test]
+    async fn it_sends_event_to_log_manga_tracking_error() -> Result<(), Box<dyn Error>> {
+        let chapter: ChapterToRead = ChapterToRead {
+            id: "some_id".to_string(),
+            title: "some_title".to_string(),
+            number: 1.0,
+            volume_number: Some(2.to_string()),
+            ..Default::default()
+        };
+
+        let mut manga_reader: MangaReader<TestApiClient, TrackerTest> =
+            MangaReader::new(chapter.clone(), "".to_string(), Picker::new((8, 8)), TestApiClient::new())
+                .with_manga_title("some_title".to_string());
+
+        let expected_error_message = "some_error_message";
+
+        let tracker = TrackerTest::failing_with_error_message(expected_error_message);
+
+        manga_reader.track_manga_reading_history(Some(tracker));
+
+        let expected = MangaReaderEvents::ErrorTrackingReadingProgress(expected_error_message.to_string());
+
+        let result = timeout(Duration::from_millis(500), manga_reader.local_event_rx.recv())
+            .await?
+            .expect("should send event");
+
+        assert_eq!(expected, result);
+
+        Ok(())
     }
 }

--- a/src/view/tasks/manga.rs
+++ b/src/view/tasks/manga.rs
@@ -411,25 +411,6 @@ pub async fn read_chapter(chapter: &ChapterArgs) -> Result<(ChapterToRead, Manga
     Ok((chapter_to_read, manga_to_read))
 }
 
-pub async fn update_reading_progress(
-    manga_title: SearchTerm,
-    chapter_number: u32,
-    volume_number: Option<u32>,
-    tracker: impl MangaTracker + Send,
-) -> Result<(), Box<dyn Error>> {
-    let response = tracker.search_manga_by_title(manga_title).await?;
-    if let Some(manga) = response {
-        tracker
-            .mark_manga_as_read_with_chapter_count(MarkAsRead {
-                id: &manga.id,
-                chapter_number,
-                volume_number,
-            })
-            .await?;
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/view/tasks/manga.rs
+++ b/src/view/tasks/manga.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
+use manga_tui::SearchTerm;
 use reqwest::Url;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -16,6 +17,8 @@ use crate::backend::fetch::ApiClient;
 #[cfg(not(test))]
 use crate::backend::fetch::MangadexClient;
 use crate::backend::filter::Languages;
+use crate::backend::tracker::anilist::MarkMangaAsReadQuery;
+use crate::backend::tracker::{MangaTracker, MarkAsRead};
 use crate::config::{DownloadType, ImageQuality, MangaTuiConfig};
 use crate::view::app::MangaToRead;
 use crate::view::pages::manga::{ChapterOrder, MangaPageEvents};
@@ -406,6 +409,25 @@ pub async fn read_chapter(chapter: &ChapterArgs) -> Result<(ChapterToRead, Manga
     };
 
     Ok((chapter_to_read, manga_to_read))
+}
+
+pub async fn update_reading_progress(
+    manga_title: SearchTerm,
+    chapter_number: u32,
+    volume_number: Option<u32>,
+    tracker: impl MangaTracker + Send,
+) -> Result<(), Box<dyn Error>> {
+    let response = tracker.search_manga_by_title(manga_title).await?;
+    if let Some(manga) = response {
+        tracker
+            .mark_manga_as_read_with_chapter_count(MarkAsRead {
+                id: &manga.id,
+                chapter_number,
+                volume_number,
+            })
+            .await?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/view/tasks/manga.rs
+++ b/src/view/tasks/manga.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
-use manga_tui::SearchTerm;
 use reqwest::Url;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -17,8 +16,6 @@ use crate::backend::fetch::ApiClient;
 #[cfg(not(test))]
 use crate::backend::fetch::MangadexClient;
 use crate::backend::filter::Languages;
-use crate::backend::tracker::anilist::MarkMangaAsReadQuery;
-use crate::backend::tracker::{MangaTracker, MarkAsRead};
 use crate::config::{DownloadType, ImageQuality, MangaTuiConfig};
 use crate::view::app::MangaToRead;
 use crate::view::pages::manga::{ChapterOrder, MangaPageEvents};


### PR DESCRIPTION
# How to test this pr 

## Steps 

1.  Login to your anilist account and go to Settings / Developer / Create new client
Name it whatever you like and put in `Redirect URL`the following : `https://anilist.co/api/v2/oauth/pin`
![image](https://github.com/user-attachments/assets/e0b1ece6-bbee-441e-9d09-0042f6a85ea8)

Assuming you have [rust](https://www.rust-lang.org/learn/get-started) on your machine 

2. clone this repo, checkout the branch `integrate-anilist` and run
```shell
cargo build --release
```
After it finishes compiling the binary will be located at `./target/release`

3. Run this command to provide your access token, follow the instructions and make sure you are logged in to your anilist account 
```shell
./manga-tui  anilist init
``` 
4. Run this command to check if everything is setup correctly 
```shell
./manga-tui  anilist check
```
5. Now just run `./manga-tui` and read manga as always, you should see your reading history being updated in your anilist account 
 
6. The config file should be updated with a new parameter
```toml
# Whether or not downloading a manga counts as reading it on services like anilist
# values : true, false
# default : false
track_reading_when_download = false
``` 
set it to `true` and downloading a chapter will update your progress as well, only when downloading single chapters